### PR TITLE
feat(react): yoga tests, based on React Native's RNTester suite

### DIFF
--- a/apps/demo-react/LICENSE_React_Native.txt
+++ b/apps/demo-react/LICENSE_React_Native.txt
@@ -1,0 +1,30 @@
+BSD License
+
+For React Native software
+
+Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -37,11 +37,11 @@
     "template"
   ],
   "dependencies": {
-    "@triniwiz/nativescript-yogalayout": "file:../../packages/nativescript-yogalayout",
     "@nativescript/core": "8.0.0-alpha.8",
     "@nativescript/theme": "3.0.0",
+    "@triniwiz/nativescript-yogalayout": "file:../../packages/nativescript-yogalayout",
     "react": "~16.13.1",
-    "react-nativescript": "^3.0.0-beta.1"
+    "react-nativescript": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "@nativescript/ios": "8.0.0",

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -41,7 +41,7 @@
     "@nativescript/theme": "3.0.0",
     "@triniwiz/nativescript-yogalayout": "file:../../packages/nativescript-yogalayout",
     "react": "~16.13.1",
-    "react-nativescript": "^3.0.0-beta.2"
+    "react-nativescript": "^3.0.0-beta.3"
   },
   "devDependencies": {
     "@nativescript/ios": "8.0.0",

--- a/apps/demo-react/src/RNTesterExamples/Button.tsx
+++ b/apps/demo-react/src/RNTesterExamples/Button.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from "react";
+import { View, Button } from "@triniwiz/nativescript-yogalayout/react";
+
+function onButtonTap(buttonName: string): void {
+  alert(`${buttonName} has been tapped!`);
+}
+
+export const displayName: string = 'ButtonExample';
+export const framework: string = 'React';
+export const title: string = '<Button>';
+export const description: string = 'Simple React Native button component.';
+
+type Example = { title: string, description?: string, render: () => any };
+
+export const examples: Example[] = [
+  {
+    title: 'Simple Button',
+    description:
+      'The title and onTap handler are required. It is ' +
+      'recommended to set accessibilityLabel to help make your app usable by ' +
+      'everyone.',
+    render: function() {
+      return (
+        <Button
+          onTap={() => onButtonTap('Simple')}
+          // testID="simple_button"
+          title="Press Me"
+          // accessibilityLabel="See an informative alert"
+        />
+      );
+    },
+  },
+  {
+    title: 'Adjusted color',
+    description:
+      'Adjusts the color in a way that looks standard on each ' +
+      'platform. On iOS, the color prop controls the color of the text. On ' +
+      'Android, the color adjusts the background color of the button.',
+    render: function() {
+      return (
+        <Button
+          onTap={() => onButtonTap('Purple')}
+          // testID="purple_button"
+          title="Press Purple"
+          color="#841584"
+          // accessibilityLabel="Learn more about purple"
+        />
+      );
+    },
+  },
+  {
+    title: 'Fit to text layout',
+    description:
+      'This layout strategy lets the title define the width of ' + 'the button',
+    render: function() {
+      return (
+        <View style={styles.container}>
+          <Button
+            onTap={() => onButtonTap('Left')}
+            // testID="left_button"
+            title="This looks great!"
+            // accessibilityLabel="This sounds great!"
+          />
+          <Button
+            onTap={() => onButtonTap('Right')}
+            // testID="right_button"
+            title="Ok!"
+            color="#841584"
+            // accessibilityLabel="Ok, Great!"
+          />
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Disabled Button',
+    description: 'All interactions for the component are disabled.',
+    render: function() {
+      return (
+        <Button
+          isEnabled={false}
+          onTap={() => onButtonTap('Disabled')}
+          // testID="disabled_button"
+          title="I Am Disabled"
+          // accessibilityLabel="See an informative alert"
+        />
+      );
+    },
+  },
+];
+
+const styles = {
+  container: {
+    flexDirection: 'row' as 'row',
+    justifyContent: 'space-between' as 'space-between',
+  },
+};

--- a/apps/demo-react/src/RNTesterExamples/Button.tsx
+++ b/apps/demo-react/src/RNTesterExamples/Button.tsx
@@ -7,6 +7,7 @@
 
 import * as React from "react";
 import { View, Button } from "@triniwiz/nativescript-yogalayout/react";
+import type { Example } from "./ExampleList";
 
 function onButtonTap(buttonName: string): void {
   alert(`${buttonName} has been tapped!`);
@@ -16,8 +17,6 @@ export const displayName: string = 'ButtonExample';
 export const framework: string = 'React';
 export const title: string = '<Button>';
 export const description: string = 'Simple React Native button component.';
-
-type Example = { title: string, description?: string, render: () => any };
 
 export const examples: Example[] = [
   {

--- a/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
+++ b/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
@@ -41,7 +41,7 @@ export function ExampleList({ examples }: ExampleListProps) {
     return (
         <scrollView orientation="vertical">
             <yoga flexDirection="column">
-                {examples.slice(0, 6).map((example, i) => {
+                {examples.map((example, i) => {
                     return cellFactory(example, `example-item-${i}`);
                 })}
             </yoga>

--- a/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
+++ b/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
@@ -5,7 +5,7 @@ import { View, Text } from "@triniwiz/nativescript-yogalayout/react";
 export interface Example {
     title: string,
     description?: string,
-    render: () => React.ReactNode,
+    render: () => JSX.Element,
 };
 
 export interface ExampleListProps {
@@ -13,6 +13,7 @@ export interface ExampleListProps {
 }
 
 const cellFactory = ({ title, description, render }: Example) => {
+    // return (<View style={styles.titleContainer}></View>);
     const descriptionComponent = description ? (<Text style={styles.descriptionText}>{description}</Text>) : null;
 
     return (
@@ -36,24 +37,28 @@ export function ExampleList({ examples }: ExampleListProps) {
 
 const styles = {
   container: {
-    // flexDirection: 'column' as const,
     borderRadius: 3,
     borderWidth: 0.5,
     borderColor: "#d6d7da",
     backgroundColor: "#ffffff",
-    margin: 10,
-    marginVertical: 5,
     overflow: 'hidden' as const,
+    margin: 10,
+
+    // FIXME: Cannot read property 'yoga' of undefined
+    // marginVertical: 5,
   },
   titleContainer: {
-    // flexDirection: 'column' as const,
     borderBottomWidth: 0.5,
     borderTopLeftRadius: 3,
     borderTopRightRadius: 2.5,
     borderBottomColor: "#d6d7da",
     backgroundColor: "#f6f7f8",
-    paddingHorizontal: 10,
-    paddingVertical: 5,
+
+    // FIXME: Cannot read property 'yoga' of undefined
+    // paddingHorizontal: 10,
+
+    // FIXME: Cannot read property 'yoga' of undefined
+    // paddingVertical: 5,
   },
   titleText: {
     fontSize: 14,
@@ -63,7 +68,6 @@ const styles = {
     fontSize: 14,
   },
   children: {
-    // flexDirection: 'column' as const,
     margin: 10,
   },
 };

--- a/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
+++ b/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
@@ -29,9 +29,21 @@ const cellFactory = ({ title, description, render }: Example) => {
     );
 };
 
+const asListView = false;
+
 export function ExampleList({ examples }: ExampleListProps) {
+    if(asListView){
+        return (
+            <ListView items={examples} cellFactory={cellFactory} />
+        );
+    }
+
     return (
-        <ListView items={examples} cellFactory={cellFactory} />
+        <yoga flexDirection="column">
+            {examples.map(example => {
+                return cellFactory(example);
+            })}
+        </yoga>
     );
 }
 

--- a/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
+++ b/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { ListView } from 'react-nativescript';
+import { View, Text } from "@triniwiz/nativescript-yogalayout/react";
+
+export interface Example {
+    title: string,
+    description?: string,
+    render: () => React.ReactNode,
+};
+
+export interface ExampleListProps {
+    examples: Example[];
+}
+
+const cellFactory = ({ title, description, render }: Example) => {
+    const descriptionComponent = description ? (<Text style={styles.descriptionText}>{description}</Text>) : null;
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.titleContainer}>
+                <Text style={styles.titleText}>{title}</Text>
+                {descriptionComponent}
+            </View>
+            <View style={styles.children}>
+                {render()}
+            </View>
+        </View>
+    );
+};
+
+export function ExampleList({ examples }: ExampleListProps) {
+    return (
+        <ListView items={examples} cellFactory={cellFactory} />
+    );
+}
+
+const styles = {
+  container: {
+    // flexDirection: 'column' as const,
+    borderRadius: 3,
+    borderWidth: 0.5,
+    borderColor: "#d6d7da",
+    backgroundColor: "#ffffff",
+    margin: 10,
+    marginVertical: 5,
+    overflow: 'hidden' as const,
+  },
+  titleContainer: {
+    // flexDirection: 'column' as const,
+    borderBottomWidth: 0.5,
+    borderTopLeftRadius: 3,
+    borderTopRightRadius: 2.5,
+    borderBottomColor: "#d6d7da",
+    backgroundColor: "#f6f7f8",
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  titleText: {
+    fontSize: 14,
+    fontWeight: 500 as any, // FontWeight.medium. Typings conflict getting in the way of using number directly.
+  },
+  descriptionText: {
+    fontSize: 14,
+  },
+  children: {
+    // flexDirection: 'column' as const,
+    margin: 10,
+  },
+};

--- a/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
+++ b/apps/demo-react/src/RNTesterExamples/ExampleList.tsx
@@ -12,12 +12,12 @@ export interface ExampleListProps {
     examples: Example[];
 }
 
-const cellFactory = ({ title, description, render }: Example) => {
+const cellFactory = ({ title, description, render }: Example, key?: string) => {
     // return (<View style={styles.titleContainer}></View>);
     const descriptionComponent = description ? (<Text style={styles.descriptionText}>{description}</Text>) : null;
 
     return (
-        <View style={styles.container}>
+        <View {...(key ? { key } : {})} style={styles.container}>
             <View style={styles.titleContainer}>
                 <Text style={styles.titleText}>{title}</Text>
                 {descriptionComponent}
@@ -39,11 +39,13 @@ export function ExampleList({ examples }: ExampleListProps) {
     }
 
     return (
-        <yoga flexDirection="column">
-            {examples.map(example => {
-                return cellFactory(example);
-            })}
-        </yoga>
+        <scrollView orientation="vertical">
+            <yoga flexDirection="column">
+                {examples.slice(0, 6).map((example, i) => {
+                    return cellFactory(example, `example-item-${i}`);
+                })}
+            </yoga>
+        </scrollView>
     );
 }
 

--- a/apps/demo-react/src/RNTesterExamples/Text.tsx
+++ b/apps/demo-react/src/RNTesterExamples/Text.tsx
@@ -424,7 +424,7 @@ class TextRenderInfoExample extends React.Component<{}, {}> {
 
 class TextWithCapBaseBox extends React.Component<
     {
-        style: TextProps["style"]
+        style?: TextProps["style"]
     },
     {}
 > {
@@ -482,12 +482,13 @@ export const examples: Example[] = [
       );
     },
   },
-  {
-    title: "Substring Emoji (should only see 'test')",
-    render: function() {
-      return <Text>{'test🙃'.substring(0, 5)}</Text>;
-    },
-  },
+  // FIXME: Fails on NativeScript iOS with a native bug.
+  // {
+  //   title: "Substring Emoji (should only see 'test')",
+  //   render: function() {
+  //     return <Text>{'test🙃'.substring(0, 5)}</Text>;
+  //   },
+  // },
   {
     title: 'Transparent Background Color',
     render: function() {
@@ -507,465 +508,465 @@ export const examples: Example[] = [
       return <TextRenderInfoExample />;
     },
   },
-// //   {
-// //     title: 'Text metrics legend',
-// //     render: () => <TextLegend />,
-// //   },
-// //   {
-// //     title: 'Baseline capheight box',
-// //     render: () => (
-// //       <View style={{backgroundColor: 'red'}}>
-// //         <TextWithCapBaseBox>Some example text.</TextWithCapBaseBox>
-// //       </View>
-// //     ),
-// //   },
   // {
-  //   title: 'Padding',
+  //   title: 'Text metrics legend',
+  //   render: () => <TextLegend />,
+  // },
+  {
+    title: 'Baseline capheight box',
+    render: () => (
+      <View style={{backgroundColor: 'red'}}>
+        <TextWithCapBaseBox>Some example text.</TextWithCapBaseBox>
+      </View>
+    ),
+  },
+  {
+    title: 'Padding',
+    render: function() {
+      return (
+        <Text style={{padding: 10}}>
+          This text is indented by 10px padding on all sides.
+        </Text>
+      );
+    },
+  },
+  {
+    title: 'Font Family',
+    render: function() {
+      return (
+        <View>
+          <Text style={{fontFamily: Platform.isTV ? 'Times' : 'Cochin'}}>
+            Cochin
+          </Text>
+          <Text
+            style={{
+              fontFamily: Platform.isTV ? 'Times' : 'Cochin',
+              fontWeight: 'bold',
+            }}>
+            Cochin bold
+          </Text>
+          <Text style={{fontFamily: 'Helvetica'}}>Helvetica</Text>
+          <Text style={{fontFamily: 'Helvetica', fontWeight: 'bold'}}>
+            Helvetica bold
+          </Text>
+          <Text style={{fontFamily: Platform.isTV ? 'Courier' : 'Verdana'}}>
+            Verdana
+          </Text>
+          <Text
+            style={{
+              fontFamily: Platform.isTV ? 'Courier' : 'Verdana',
+              fontWeight: 'bold',
+            }}>
+            Verdana bold
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Font Size',
+    render: function() {
+      return (
+        <View>
+          <Text style={{fontSize: 23}}>Size 23</Text>
+          <Text style={{fontSize: 8}}>Size 8</Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Color',
+    render: function() {
+      return (
+        <View>
+          <Text style={{color: 'red'}}>Red color</Text>
+          <Text style={{color: 'blue'}}>Blue color</Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Font Weight',
+    render: function() {
+      return (
+        <View>
+          <Text style={{fontSize: 20, fontWeight: '100'}}>
+            Move fast and be ultralight
+          </Text>
+          <Text style={{fontSize: 20, fontWeight: '200'}}>
+            Move fast and be light
+          </Text>
+          <Text style={{fontSize: 20, fontWeight: 'normal'}}>
+            Move fast and be normal
+          </Text>
+          <Text style={{fontSize: 20, fontWeight: 'bold'}}>
+            Move fast and be bold
+          </Text>
+          <Text style={{fontSize: 20, fontWeight: '900'}}>
+            Move fast and be ultrabold
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Font Style',
+    render: function() {
+      return (
+        <View>
+          <Text style={{fontStyle: 'normal'}}>Normal text</Text>
+          <Text style={{fontStyle: 'italic'}}>Italic text</Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Selectable',
+    render: function() {
+      return (
+        <View>
+          <Text selectable={true}>
+            This text is <Text style={{fontWeight: 'bold'}}>selectable</Text> if
+            you click-and-hold.
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Text Decoration',
+    render: function() {
+      return (
+        <View>
+          <Text
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'solid',
+            }}>
+            Solid underline
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'double',
+              textDecorationColor: '#ff0000',
+            }}>
+            Double underline with custom color
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'dashed',
+              textDecorationColor: '#9CDC40',
+            }}>
+            Dashed underline with custom color
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'dotted',
+              textDecorationColor: 'blue',
+            }}>
+            Dotted underline with custom color
+          </Text>
+          <Text style={{textDecorationLine: 'none'}}>None textDecoration</Text>
+          <Text
+            style={{
+              textDecorationLine: 'line-through',
+              textDecorationStyle: 'solid',
+            }}>
+            Solid line-through
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'line-through',
+              textDecorationStyle: 'double',
+              textDecorationColor: '#ff0000',
+            }}>
+            Double line-through with custom color
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'line-through',
+              textDecorationStyle: 'dashed',
+              textDecorationColor: '#9CDC40',
+            }}>
+            Dashed line-through with custom color
+          </Text>
+          <Text
+            style={{
+              textDecorationLine: 'line-through',
+              textDecorationStyle: 'dotted',
+              textDecorationColor: 'blue',
+            }}>
+            Dotted line-through with custom color
+          </Text>
+          <Text style={{textDecorationLine: 'underline line-through'}}>
+            Both underline and line-through
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Nested',
+    description:
+      'Nested text components will inherit the styles of their ' +
+      'parents (only backgroundColor is inherited from non-Text parents).  ' +
+      '<Text> only supports other <Text> and raw text (strings) as children.',
+    render: function() {
+      return (
+        <View>
+          <Text>
+            (Normal text,
+            <Text style={{fontWeight: 'bold'}}>
+              (and bold
+              <Text style={{fontSize: 11, color: '#527fe4'}}>
+                (and tiny inherited bold blue)
+              </Text>
+              )
+            </Text>
+            )
+          </Text>
+          <Text style={{opacity: 0.7}}>
+            (opacity
+            <Text>
+              (is inherited
+              <Text style={{opacity: 0.7}}>
+                (and accumulated
+                <Text style={{backgroundColor: '#ffaaaa'}}>
+                  (and also applies to the background)
+                </Text>
+                )
+              </Text>
+              )
+            </Text>
+            )
+          </Text>
+          <Text style={{fontSize: 12}}>
+            <Entity>Entity Name</Entity>
+          </Text>
+        </View>
+      );
+    },
+  },
+
+  /* Slow example to load in, but does run in the end. */
+  // {
+  //   title: 'Text Align',
   //   render: function() {
   //     return (
-  //       <Text style={{padding: 10}}>
-  //         This text is indented by 10px padding on all sides.
+  //       <View>
+  //         <Text>auto (default) - english LTR</Text>
+  //         <Text>
+  //           {'\u0623\u062D\u0628 \u0627\u0644\u0644\u063A\u0629 ' +
+  //             '\u0627\u0644\u0639\u0631\u0628\u064A\u0629 auto (default) - arabic ' +
+  //             'RTL'}
+  //         </Text>
+  //         <Text style={{textAlign: 'left'}}>
+  //           left left left left left left left left left left left left left
+  //           left left
+  //         </Text>
+  //         <Text style={{textAlign: 'center'}}>
+  //           center center center center center center center center center
+  //           center center
+  //         </Text>
+  //         <Text style={{textAlign: 'right'}}>
+  //           right right right right right right right right right right right
+  //           right right
+  //         </Text>
+  //         <Text style={{textAlign: 'justify'}}>
+  //           justify: this text component{"'"}s contents are laid out with
+  //           "textAlign: justify" and as you can see all of the lines except the
+  //           last one span the available width of the parent container.
+  //         </Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  {
+    title: 'Letter Spacing',
+    render: function() {
+      return (
+        <View>
+          <Text style={{letterSpacing: 0}}>letterSpacing = 0</Text>
+          <Text style={{letterSpacing: 2, marginTop: 5}}>
+            letterSpacing = 2
+          </Text>
+          <Text style={{letterSpacing: 9, marginTop: 5}}>
+            letterSpacing = 9
+          </Text>
+          <View style={{flexDirection: 'row'}}>
+            <Text
+              style={{
+                fontSize: 12,
+                letterSpacing: 2,
+                backgroundColor: 'fuchsia',
+                marginTop: 5,
+              }}>
+              With size and background color
+            </Text>
+          </View>
+          <Text style={{letterSpacing: -1, marginTop: 5}}>
+            letterSpacing = -1
+          </Text>
+          <Text
+            style={{
+              letterSpacing: 3,
+              backgroundColor: '#dddddd',
+              marginTop: 5,
+            }}>
+            [letterSpacing = 3]
+            <Text style={{letterSpacing: 0, backgroundColor: '#bbbbbb'}}>
+              [Nested letterSpacing = 0]
+            </Text>
+            <Text style={{letterSpacing: 6, backgroundColor: '#eeeeee'}}>
+              [Nested letterSpacing = 6]
+            </Text>
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Spaces',
+    render: function() {
+      return (
+        <Text>
+          A {'generated'} {'string'} and some &nbsp;&nbsp;&nbsp; spaces
+        </Text>
+      );
+    },
+  },
+  {
+    title: 'Line Height',
+    render: function() {
+      return (
+        <Text>
+          <Text style={{lineHeight: 35}}>
+            A lot of space between the lines of this long passage that should
+            wrap once.
+          </Text>
+        </Text>
+      );
+    },
+  },
+  {
+    title: 'Empty Text',
+    description: "It's ok to have Text with zero or null children.",
+    render: function() {
+      return <Text />;
+    },
+  },
+  {
+    title: 'Toggling Attributes',
+    render: function() {
+      return <AttributeToggler />;
+    },
+  },
+  /* Very slow to load, but does run */
+  // {
+  //   title: 'backgroundColor attribute',
+  //   description: 'backgroundColor is inherited from all types of views.',
+  //   render: function() {
+  //     return (
+  //       <Text style={{backgroundColor: 'yellow'}}>
+  //         Yellow container background,
+  //         <Text style={{backgroundColor: '#ffaaaa'}}>
+  //           {' '}
+  //           red background,
+  //           <Text style={{backgroundColor: '#aaaaff'}}>
+  //             {' '}
+  //             blue background,
+  //             <Text>
+  //               {' '}
+  //               inherited blue background,
+  //               <Text style={{backgroundColor: '#aaffaa'}}>
+  //                 {' '}
+  //                 nested green background.
+  //               </Text>
+  //             </Text>
+  //           </Text>
+  //         </Text>
   //       </Text>
   //     );
   //   },
   // },
-  // {
-  //   title: 'Font Family',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text style={{fontFamily: Platform.isTV ? 'Times' : 'Cochin'}}>
-  //           Cochin
-  //         </Text>
-  //         <Text
-  //           style={{
-  //             fontFamily: Platform.isTV ? 'Times' : 'Cochin',
-  //             fontWeight: 'bold',
-  //           }}>
-  //           Cochin bold
-  //         </Text>
-  //         <Text style={{fontFamily: 'Helvetica'}}>Helvetica</Text>
-  //         <Text style={{fontFamily: 'Helvetica', fontWeight: 'bold'}}>
-  //           Helvetica bold
-  //         </Text>
-  //         <Text style={{fontFamily: Platform.isTV ? 'Courier' : 'Verdana'}}>
-  //           Verdana
-  //         </Text>
-  //         <Text
-  //           style={{
-  //             fontFamily: Platform.isTV ? 'Courier' : 'Verdana',
-  //             fontWeight: 'bold',
-  //           }}>
-  //           Verdana bold
-  //         </Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-  // {
-  //   title: 'Font Size',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text style={{fontSize: 23}}>Size 23</Text>
-  //         <Text style={{fontSize: 8}}>Size 8</Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-  // {
-  //   title: 'Color',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text style={{color: 'red'}}>Red color</Text>
-  //         <Text style={{color: 'blue'}}>Blue color</Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-  // {
-  //   title: 'Font Weight',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text style={{fontSize: 20, fontWeight: '100'}}>
-  //           Move fast and be ultralight
-  //         </Text>
-  //         <Text style={{fontSize: 20, fontWeight: '200'}}>
-  //           Move fast and be light
-  //         </Text>
-  //         <Text style={{fontSize: 20, fontWeight: 'normal'}}>
-  //           Move fast and be normal
-  //         </Text>
-  //         <Text style={{fontSize: 20, fontWeight: 'bold'}}>
-  //           Move fast and be bold
-  //         </Text>
-  //         <Text style={{fontSize: 20, fontWeight: '900'}}>
-  //           Move fast and be ultrabold
-  //         </Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-  // {
-  //   title: 'Font Style',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text style={{fontStyle: 'normal'}}>Normal text</Text>
-  //         <Text style={{fontStyle: 'italic'}}>Italic text</Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-  // {
-  //   title: 'Selectable',
-  //   render: function() {
-  //     return (
-  //       <View>
-  //         <Text selectable={true}>
-  //           This text is <Text style={{fontWeight: 'bold'}}>selectable</Text> if
-  //           you click-and-hold.
-  //         </Text>
-  //       </View>
-  //     );
-  //   },
-  // },
-//   {
-//     title: 'Text Decoration',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text
-//             style={{
-//               textDecorationLine: 'underline',
-//               textDecorationStyle: 'solid',
-//             }}>
-//             Solid underline
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'underline',
-//               textDecorationStyle: 'double',
-//               textDecorationColor: '#ff0000',
-//             }}>
-//             Double underline with custom color
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'underline',
-//               textDecorationStyle: 'dashed',
-//               textDecorationColor: '#9CDC40',
-//             }}>
-//             Dashed underline with custom color
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'underline',
-//               textDecorationStyle: 'dotted',
-//               textDecorationColor: 'blue',
-//             }}>
-//             Dotted underline with custom color
-//           </Text>
-//           <Text style={{textDecorationLine: 'none'}}>None textDecoration</Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'line-through',
-//               textDecorationStyle: 'solid',
-//             }}>
-//             Solid line-through
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'line-through',
-//               textDecorationStyle: 'double',
-//               textDecorationColor: '#ff0000',
-//             }}>
-//             Double line-through with custom color
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'line-through',
-//               textDecorationStyle: 'dashed',
-//               textDecorationColor: '#9CDC40',
-//             }}>
-//             Dashed line-through with custom color
-//           </Text>
-//           <Text
-//             style={{
-//               textDecorationLine: 'line-through',
-//               textDecorationStyle: 'dotted',
-//               textDecorationColor: 'blue',
-//             }}>
-//             Dotted line-through with custom color
-//           </Text>
-//           <Text style={{textDecorationLine: 'underline line-through'}}>
-//             Both underline and line-through
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Nested',
-//     description:
-//       'Nested text components will inherit the styles of their ' +
-//       'parents (only backgroundColor is inherited from non-Text parents).  ' +
-//       '<Text> only supports other <Text> and raw text (strings) as children.',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text>
-//             (Normal text,
-//             <Text style={{fontWeight: 'bold'}}>
-//               (and bold
-//               <Text style={{fontSize: 11, color: '#527fe4'}}>
-//                 (and tiny inherited bold blue)
-//               </Text>
-//               )
-//             </Text>
-//             )
-//           </Text>
-//           <Text style={{opacity: 0.7}}>
-//             (opacity
-//             <Text>
-//               (is inherited
-//               <Text style={{opacity: 0.7}}>
-//                 (and accumulated
-//                 <Text style={{backgroundColor: '#ffaaaa'}}>
-//                   (and also applies to the background)
-//                 </Text>
-//                 )
-//               </Text>
-//               )
-//             </Text>
-//             )
-//           </Text>
-//           <Text style={{fontSize: 12}}>
-//             <Entity>Entity Name</Entity>
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-
-//   /* Slow example to load in, but does run in the end. */
-//   {
-//     title: 'Text Align',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text>auto (default) - english LTR</Text>
-//           <Text>
-//             {'\u0623\u062D\u0628 \u0627\u0644\u0644\u063A\u0629 ' +
-//               '\u0627\u0644\u0639\u0631\u0628\u064A\u0629 auto (default) - arabic ' +
-//               'RTL'}
-//           </Text>
-//           <Text style={{textAlign: 'left'}}>
-//             left left left left left left left left left left left left left
-//             left left
-//           </Text>
-//           <Text style={{textAlign: 'center'}}>
-//             center center center center center center center center center
-//             center center
-//           </Text>
-//           <Text style={{textAlign: 'right'}}>
-//             right right right right right right right right right right right
-//             right right
-//           </Text>
-//           <Text style={{textAlign: 'justify'}}>
-//             justify: this text component{"'"}s contents are laid out with
-//             "textAlign: justify" and as you can see all of the lines except the
-//             last one span the available width of the parent container.
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Letter Spacing',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text style={{letterSpacing: 0}}>letterSpacing = 0</Text>
-//           <Text style={{letterSpacing: 2, marginTop: 5}}>
-//             letterSpacing = 2
-//           </Text>
-//           <Text style={{letterSpacing: 9, marginTop: 5}}>
-//             letterSpacing = 9
-//           </Text>
-//           <View style={{flexDirection: 'row'}}>
-//             <Text
-//               style={{
-//                 fontSize: 12,
-//                 letterSpacing: 2,
-//                 backgroundColor: 'fuchsia',
-//                 marginTop: 5,
-//               }}>
-//               With size and background color
-//             </Text>
-//           </View>
-//           <Text style={{letterSpacing: -1, marginTop: 5}}>
-//             letterSpacing = -1
-//           </Text>
-//           <Text
-//             style={{
-//               letterSpacing: 3,
-//               backgroundColor: '#dddddd',
-//               marginTop: 5,
-//             }}>
-//             [letterSpacing = 3]
-//             <Text style={{letterSpacing: 0, backgroundColor: '#bbbbbb'}}>
-//               [Nested letterSpacing = 0]
-//             </Text>
-//             <Text style={{letterSpacing: 6, backgroundColor: '#eeeeee'}}>
-//               [Nested letterSpacing = 6]
-//             </Text>
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Spaces',
-//     render: function() {
-//       return (
-//         <Text>
-//           A {'generated'} {'string'} and some &nbsp;&nbsp;&nbsp; spaces
-//         </Text>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Line Height',
-//     render: function() {
-//       return (
-//         <Text>
-//           <Text style={{lineHeight: 35}}>
-//             A lot of space between the lines of this long passage that should
-//             wrap once.
-//           </Text>
-//         </Text>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Empty Text',
-//     description: "It's ok to have Text with zero or null children.",
-//     render: function() {
-//       return <Text />;
-//     },
-//   },
-//   {
-//     title: 'Toggling Attributes',
-//     render: function(): React.ReactElement<any> {
-//       return <AttributeToggler />;
-//     },
-//   },
-//   /* Very slow to load, but does run */
-//   {
-//     title: 'backgroundColor attribute',
-//     description: 'backgroundColor is inherited from all types of views.',
-//     render: function() {
-//       return (
-//         <Text style={{backgroundColor: 'yellow'}}>
-//           Yellow container background,
-//           <Text style={{backgroundColor: '#ffaaaa'}}>
-//             {' '}
-//             red background,
-//             <Text style={{backgroundColor: '#aaaaff'}}>
-//               {' '}
-//               blue background,
-//               <Text>
-//                 {' '}
-//                 inherited blue background,
-//                 <Text style={{backgroundColor: '#aaffaa'}}>
-//                   {' '}
-//                   nested green background.
-//                 </Text>
-//               </Text>
-//             </Text>
-//           </Text>
-//         </Text>
-//       );
-//     },
-//   },
-//   {
-//     title: 'numberOfLines attribute',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text numberOfLines={1}>
-//             Maximum of one line, no matter how much I write here. If I keep
-//             writing, it{"'"}ll just truncate after one line.
-//           </Text>
-//           <Text numberOfLines={2} style={{marginTop: 20}}>
-//             Maximum of two lines, no matter how much I write here. If I keep
-//             writing, it{"'"}ll just truncate after two lines.
-//           </Text>
-//           <Text style={{marginTop: 20}}>
-//             No maximum lines specified, no matter how much I write here. If I
-//             keep writing, it{"'"}ll just keep going and going.
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-//   {
-//     title: 'Text highlighting (tap the link to see highlight)',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text>
-//             Lorem ipsum dolor sit amet,{' '}
-//             <Text
-//               suppressHighlighting={false}
-//               style={{
-//                 backgroundColor: 'white',
-//                 textDecorationLine: 'underline',
-//                 color: 'blue',
-//               }}
-//               onPress={() => null}>
-//               consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-//               labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-//               nostrud
-//             </Text>{' '}
-//             exercitation ullamco laboris nisi ut aliquip ex ea commodo
-//             consequat.
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
-//   {
-//     title: 'allowFontScaling attribute',
-//     render: function() {
-//       return (
-//         <View>
-//           <Text>
-//             By default, text will respect Text Size accessibility setting on
-//             iOS. It means that all font sizes will be increased or decreased
-//             depending on the value of Text Size setting in{' '}
-//             <Text style={{fontWeight: 'bold'}}>
-//               Settings.app - Display & Brightness - Text Size
-//             </Text>
-//           </Text>
-//           <Text style={{marginTop: 10}}>
-//             You can disable scaling for your Text component by passing {'"'}
-//             allowFontScaling={'{'}false{'}"'} prop.
-//           </Text>
-//           <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
-//             This text will not scale.{' '}
-//             <Text style={{fontSize: 15}}>
-//               This text also won't scale because it inherits "allowFontScaling"
-//               from its parent.
-//             </Text>
-//           </Text>
-//         </View>
-//       );
-//     },
-//   },
+  {
+    title: 'numberOfLines attribute',
+    render: function() {
+      return (
+        <View>
+          <Text numberOfLines={1}>
+            Maximum of one line, no matter how much I write here. If I keep
+            writing, it{"'"}ll just truncate after one line.
+          </Text>
+          <Text numberOfLines={2} style={{marginTop: 20}}>
+            Maximum of two lines, no matter how much I write here. If I keep
+            writing, it{"'"}ll just truncate after two lines.
+          </Text>
+          <Text style={{marginTop: 20}}>
+            No maximum lines specified, no matter how much I write here. If I
+            keep writing, it{"'"}ll just keep going and going.
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Text highlighting (tap the link to see highlight)',
+    render: function() {
+      return (
+        <View>
+          <Text>
+            Lorem ipsum dolor sit amet,{' '}
+            <Text
+              suppressHighlighting={false}
+              style={{
+                backgroundColor: 'white',
+                textDecorationLine: 'underline',
+                color: 'blue',
+              }}
+              onPress={() => null}>
+              consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+              labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+              nostrud
+            </Text>{' '}
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat.
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'allowFontScaling attribute',
+    render: function() {
+      return (
+        <View>
+          <Text>
+            By default, text will respect Text Size accessibility setting on
+            iOS. It means that all font sizes will be increased or decreased
+            depending on the value of Text Size setting in{' '}
+            <Text style={{fontWeight: 'bold'}}>
+              Settings.app - Display & Brightness - Text Size
+            </Text>
+          </Text>
+          <Text style={{marginTop: 10}}>
+            You can disable scaling for your Text component by passing {'"'}
+            allowFontScaling={'{'}false{'}"'} prop.
+          </Text>
+          <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
+            This text will not scale.{' '}
+            <Text style={{fontSize: 15}}>
+              This text also won't scale because it inherits "allowFontScaling"
+              from its parent.
+            </Text>
+          </Text>
+        </View>
+      );
+    },
+  },
 // //   {
 // //     title: 'Inline views',
 // //     render: () => <TextInlineView.Basic />,

--- a/apps/demo-react/src/RNTesterExamples/Text.tsx
+++ b/apps/demo-react/src/RNTesterExamples/Text.tsx
@@ -1,0 +1,1145 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import * as React from "react";
+import { View, Text, TextInput, Button, TextProps } from "@triniwiz/nativescript-yogalayout/react";
+
+const Platform = {
+  isTV: false
+};
+
+// const React = require('react');
+// const {
+//   Button,
+//   LayoutAnimation,
+//   Platform,
+//   Text,
+//   TextInput,
+//   View,
+// } = require('react-native');
+
+// const TextAncestor = require('../../../../Libraries/Text/TextAncestor');
+// const TextInlineView = require('../../components/TextInlineView');
+// const TextLegend = require('../../components/TextLegend');
+
+/* TODO (FB): Is there a cleaner way to flip the TextAncestor value to false? I
+ *   suspect apps won't even be able to leverage this workaround because
+ *   TextAncestor is not public. */
+// function InlineView(props) {
+//   return (
+//     <TextAncestor.Provider value={false}>
+//       <View {...props} />
+//     </TextAncestor.Provider>
+//   );
+// }
+
+type TextAlignExampleRTLState = {
+  isRTL: boolean,
+};
+
+class TextAlignRTLExample extends React.Component<{}, TextAlignExampleRTLState> {
+  constructor(props: {}){
+    super(props);
+
+    this.state = {
+      isRTL: false,
+    };
+  }
+
+  render() {
+    const {isRTL} = this.state;
+    const toggleRTL = () => this.setState({isRTL: !isRTL});
+    return (
+      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+        <Text>auto (default) - english LTR</Text>
+        <Text>
+          {'\u0623\u062D\u0628 \u0627\u0644\u0644\u063A\u0629 ' +
+            '\u0627\u0644\u0639\u0631\u0628\u064A\u0629 auto (default) - arabic RTL'}
+        </Text>
+        <Text style={{textAlign: 'left'}}>
+          left left left left left left left left left left left left left left
+          left
+        </Text>
+        <Text style={{textAlign: 'center'}}>
+          center center center center center center center center center center
+          center
+        </Text>
+        <Text style={{textAlign: 'right'}}>
+          right right right right right right right right right right right
+          right right
+        </Text>
+        <Text style={{textAlign: 'justify'}}>
+          justify: this text component{"'"}s contents are laid out with
+          "textAlign: justify" and as you can see all of the lines except the
+          last one span the available width of the parent container.
+        </Text>
+        <Button
+          onPress={toggleRTL}
+          title={`Switch to ${isRTL ? 'LTR' : 'RTL'}`}
+        />
+      </View>
+    );
+  }
+}
+
+class Entity extends React.Component<{}> {
+  render() {
+    return (
+      <Text style={{fontWeight: '500', color: '#527fe4'}}>
+        {this.props.children}
+      </Text>
+    );
+  }
+}
+
+class AttributeToggler extends React.Component<{}, {}> {
+  state = {fontWeight: 'bold', fontSize: 15};
+
+  toggleWeight = () => {
+    this.setState({
+      fontWeight: this.state.fontWeight === 'bold' ? 'normal' : 'bold',
+    });
+  };
+
+  increaseSize = () => {
+    this.setState({
+      fontSize: this.state.fontSize + 1,
+    });
+  };
+
+  render() {
+    const curStyle = {
+      fontWeight: this.state.fontWeight,
+      fontSize: this.state.fontSize,
+    };
+    return (
+      <View>
+        <Text style={curStyle}>
+          Tap the controls below to change attributes.
+        </Text>
+        <Text>
+          <Text>
+            See how it will even work on{' '}
+            <Text style={curStyle}>this nested text</Text>
+          </Text>
+        </Text>
+        <Text
+          style={{backgroundColor: '#ffaaaa', marginTop: 5}}
+          onPress={this.toggleWeight}>
+          Toggle Weight
+        </Text>
+        <Text
+          style={{backgroundColor: '#aaaaff', marginTop: 5}}
+          onPress={this.increaseSize}>
+          Increase Size
+        </Text>
+      </View>
+    );
+  }
+}
+
+// type AdjustingFontSizeProps = {};
+
+// type AdjustingFontSizeState = {
+//   dynamicText: string,
+//   shouldRender: boolean,
+// };
+
+// class AdjustingFontSize extends React.Component<
+//   AdjustingFontSizeProps,
+//   AdjustingFontSizeState,
+// > {
+//   state = {
+//     dynamicText: '',
+//     shouldRender: true,
+//   };
+
+//   reset = () => {
+//     LayoutAnimation.easeInEaseOut();
+//     this.setState({
+//       shouldRender: false,
+//     });
+//     setTimeout(() => {
+//       LayoutAnimation.easeInEaseOut();
+//       this.setState({
+//         dynamicText: '',
+//         shouldRender: true,
+//       });
+//     }, 300);
+//   };
+
+//   addText = () => {
+//     this.setState({
+//       dynamicText:
+//         this.state.dynamicText +
+//         (Math.floor((Math.random() * 10) % 2) ? ' foo' : ' bar'),
+//     });
+//   };
+
+//   removeText = () => {
+//     this.setState({
+//       dynamicText: this.state.dynamicText.slice(
+//         0,
+//         this.state.dynamicText.length - 4,
+//       ),
+//     });
+//   };
+
+//   render() {
+//     if (!this.state.shouldRender) {
+//       return <View />;
+//     }
+//     return (
+//       <View>
+//         <Text
+//           ellipsizeMode="tail"
+//           numberOfLines={1}
+//           style={{fontSize: 36, marginVertical: 6}}>
+//           Truncated text is baaaaad.
+//         </Text>
+//         <Text
+//           numberOfLines={1}
+//           adjustsFontSizeToFit={true}
+//           style={{fontSize: 40, marginVertical: 6}}>
+//           Shrinking to fit available space is much better!
+//         </Text>
+
+//         <Text
+//           adjustsFontSizeToFit={true}
+//           numberOfLines={1}
+//           style={{fontSize: 30, marginVertical: 6}}>
+//           {'Add text to me to watch me shrink!' + ' ' + this.state.dynamicText}
+//         </Text>
+
+//         <Text
+//           adjustsFontSizeToFit={true}
+//           numberOfLines={4}
+//           style={{fontSize: 20, marginVertical: 6}}>
+//           {'Multiline text component shrinking is supported, watch as this reeeeaaaally loooooong teeeeeeext grooooows and then shriiiinks as you add text to me! ioahsdia soady auydoa aoisyd aosdy ' +
+//             ' ' +
+//             this.state.dynamicText}
+//         </Text>
+
+//         <Text
+//           adjustsFontSizeToFit={true}
+//           numberOfLines={1}
+//           style={{marginVertical: 6}}>
+//           <Text style={{fontSize: 14}}>
+//             {'Differently sized nested elements will shrink together. '}
+//           </Text>
+//           <Text style={{fontSize: 20}}>
+//             {'LARGE TEXT! ' + this.state.dynamicText}
+//           </Text>
+//         </Text>
+
+//         <View
+//           style={{
+//             flexDirection: 'row',
+//             justifyContent: 'space-around',
+//             marginTop: 5,
+//             marginVertical: 6,
+//           }}>
+//           <Text style={{backgroundColor: '#ffaaaa'}} onPress={this.reset}>
+//             Reset
+//           </Text>
+//           <Text style={{backgroundColor: '#aaaaff'}} onPress={this.removeText}>
+//             Remove Text
+//           </Text>
+//           <Text style={{backgroundColor: '#aaffaa'}} onPress={this.addText}>
+//             Add Text
+//           </Text>
+//         </View>
+//       </View>
+//     );
+//   }
+// }
+
+class TextBaseLineLayoutExample extends React.Component<{}, {}> {
+  render() {
+    const texts = [];
+    for (let i = 9; i >= 0; i--) {
+      texts.push(
+        <Text key={i} style={{fontSize: 8 + i * 5, backgroundColor: '#eee'}}>
+          {i}
+        </Text>,
+      );
+    }
+
+    const marker = (
+      <View style={{width: 20, height: 20, backgroundColor: 'gray'}} />
+    );
+    const subtitleStyle = {fontSize: 16, marginTop: 8, fontWeight: 'bold'};
+
+    return (
+      <View>
+        <Text style={subtitleStyle}>{'Nested <Text/>s:'}</Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          {marker}
+          <Text>{texts}</Text>
+          {marker}
+        </View>
+
+        <Text style={subtitleStyle}>{'Array of <Text/>s in <View>:'}</Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          {marker}
+          {texts}
+          {marker}
+        </View>
+
+        {/* iOS-only because it relies on inline views being able to size to content.
+         * Android's implementation requires that a width and height be specified
+         * on the inline view. */}
+        {/* <Text style={subtitleStyle}>{'Interleaving <View> and <Text>:'}</Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          {marker}
+          <Text selectable={true}>
+            Some text.
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'baseline',
+                backgroundColor: '#eee',
+              }}>
+              {marker}
+              <Text>Text inside View.</Text>
+              {marker}
+            </View>
+          </Text>
+          {marker}
+        </View> */}
+
+        <Text style={subtitleStyle}>{'<TextInput/>:'}</Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          {marker}
+          <TextInput style={{margin: 0, padding: 0}}>{texts}</TextInput>
+          {marker}
+        </View>
+
+        <Text style={subtitleStyle}>{'<TextInput multiline/>:'}</Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          {marker}
+          <TextInput multiline={true} style={{margin: 0, padding: 0}}>
+            {texts}
+          </TextInput>
+          {marker}
+        </View>
+      </View>
+    );
+  }
+}
+
+class TextRenderInfoExample extends React.Component<{}, {}> {
+  state = {
+    textMetrics: {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      capHeight: 0,
+      descender: 0,
+      ascender: 0,
+      xHeight: 0,
+    },
+    numberOfTextBlocks: 1,
+    fontSize: 14,
+  };
+
+  render() {
+    const topOfBox =
+      this.state.textMetrics.y +
+      this.state.textMetrics.height -
+      (this.state.textMetrics.descender + this.state.textMetrics.capHeight);
+    return (
+      <View>
+        <View>
+          <View
+            style={{
+              position: 'absolute',
+              left: this.state.textMetrics.x + this.state.textMetrics.width,
+              top: topOfBox,
+              width: 5,
+              height: Math.ceil(
+                this.state.textMetrics.capHeight -
+                  this.state.textMetrics.xHeight,
+              ),
+              backgroundColor: 'red',
+            }}
+          />
+          <View
+            style={{
+              position: 'absolute',
+              left: this.state.textMetrics.x + this.state.textMetrics.width,
+              top:
+                topOfBox +
+                (this.state.textMetrics.capHeight -
+                  this.state.textMetrics.xHeight),
+              width: 5,
+              height: Math.ceil(this.state.textMetrics.xHeight),
+              backgroundColor: 'green',
+            }}
+          />
+          <Text
+            style={{fontSize: this.state.fontSize}}
+            onTextLayout={event => {
+              const {lines} = event.nativeEvent;
+              if (lines.length > 0) {
+                this.setState({textMetrics: lines[lines.length - 1]});
+              }
+            }}>
+            {new Array(this.state.numberOfTextBlocks)
+              .fill('A tiny block of text.')
+              .join(' ')}
+          </Text>
+        </View>
+        <Text
+          onPress={() =>
+            this.setState({
+              numberOfTextBlocks: this.state.numberOfTextBlocks + 1,
+            })
+          }>
+          More text
+        </Text>
+        <Text
+          onPress={() => this.setState({fontSize: this.state.fontSize + 1})}>
+          Increase size
+        </Text>
+        <Text
+          onPress={() => this.setState({fontSize: this.state.fontSize - 1})}>
+          Decrease size
+        </Text>
+      </View>
+    );
+  }
+}
+
+class TextWithCapBaseBox extends React.Component<
+    {
+        style: TextProps["style"]
+    },
+    {}
+> {
+  state = {
+    textMetrics: {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      capHeight: 0,
+      descender: 0,
+      ascender: 0,
+      xHeight: 0,
+    },
+  };
+  render() {
+    return (
+      <Text
+        onTextLayout={event => {
+          const {lines} = event.nativeEvent;
+          if (lines.length > 0) {
+            this.setState({textMetrics: lines[0]});
+          }
+        }}
+        style={[
+          {
+            marginTop: Math.ceil(
+              -(
+                this.state.textMetrics.ascender -
+                this.state.textMetrics.capHeight
+              ),
+            ),
+            marginBottom: Math.ceil(-this.state.textMetrics.descender),
+          },
+          this.props.style,
+        ]}>
+        {this.props.children}
+      </Text>
+    );
+  }
+}
+
+export const title: string = '<Text>';
+export const description: string = 'Base component for rendering styled text.';
+export const displayName: string = 'TextExample';
+type Example = { title: string, description?: string, render: () => any };
+export const examples: Example[] = [
+  {
+    title: 'Wrap',
+    render: function() {
+      return (
+        <Text>
+          The text should wrap if it goes on multiple lines. See, this is going
+          to the next line.
+        </Text>
+      );
+    },
+  },
+  {
+    title: "Substring Emoji (should only see 'test')",
+    render: function() {
+      return <Text>{'test🙃'.substring(0, 5)}</Text>;
+    },
+  },
+  {
+    title: 'Transparent Background Color',
+    render: function() {
+      return (
+        <Text style={{backgroundColor: '#00000020', padding: 10}}>
+          Text in a gray box!
+          <Text style={{backgroundColor: 'red'}}>
+            Another text in a (inline) red box (which is inside the gray box).
+          </Text>
+        </Text>
+      );
+    },
+  },
+  {
+    title: 'Text metrics',
+    render: function() {
+      return <TextRenderInfoExample />;
+    },
+  },
+// //   {
+// //     title: 'Text metrics legend',
+// //     render: () => <TextLegend />,
+// //   },
+// //   {
+// //     title: 'Baseline capheight box',
+// //     render: () => (
+// //       <View style={{backgroundColor: 'red'}}>
+// //         <TextWithCapBaseBox>Some example text.</TextWithCapBaseBox>
+// //       </View>
+// //     ),
+// //   },
+  // {
+  //   title: 'Padding',
+  //   render: function() {
+  //     return (
+  //       <Text style={{padding: 10}}>
+  //         This text is indented by 10px padding on all sides.
+  //       </Text>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Font Family',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text style={{fontFamily: Platform.isTV ? 'Times' : 'Cochin'}}>
+  //           Cochin
+  //         </Text>
+  //         <Text
+  //           style={{
+  //             fontFamily: Platform.isTV ? 'Times' : 'Cochin',
+  //             fontWeight: 'bold',
+  //           }}>
+  //           Cochin bold
+  //         </Text>
+  //         <Text style={{fontFamily: 'Helvetica'}}>Helvetica</Text>
+  //         <Text style={{fontFamily: 'Helvetica', fontWeight: 'bold'}}>
+  //           Helvetica bold
+  //         </Text>
+  //         <Text style={{fontFamily: Platform.isTV ? 'Courier' : 'Verdana'}}>
+  //           Verdana
+  //         </Text>
+  //         <Text
+  //           style={{
+  //             fontFamily: Platform.isTV ? 'Courier' : 'Verdana',
+  //             fontWeight: 'bold',
+  //           }}>
+  //           Verdana bold
+  //         </Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Font Size',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text style={{fontSize: 23}}>Size 23</Text>
+  //         <Text style={{fontSize: 8}}>Size 8</Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Color',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text style={{color: 'red'}}>Red color</Text>
+  //         <Text style={{color: 'blue'}}>Blue color</Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Font Weight',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text style={{fontSize: 20, fontWeight: '100'}}>
+  //           Move fast and be ultralight
+  //         </Text>
+  //         <Text style={{fontSize: 20, fontWeight: '200'}}>
+  //           Move fast and be light
+  //         </Text>
+  //         <Text style={{fontSize: 20, fontWeight: 'normal'}}>
+  //           Move fast and be normal
+  //         </Text>
+  //         <Text style={{fontSize: 20, fontWeight: 'bold'}}>
+  //           Move fast and be bold
+  //         </Text>
+  //         <Text style={{fontSize: 20, fontWeight: '900'}}>
+  //           Move fast and be ultrabold
+  //         </Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Font Style',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text style={{fontStyle: 'normal'}}>Normal text</Text>
+  //         <Text style={{fontStyle: 'italic'}}>Italic text</Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+  // {
+  //   title: 'Selectable',
+  //   render: function() {
+  //     return (
+  //       <View>
+  //         <Text selectable={true}>
+  //           This text is <Text style={{fontWeight: 'bold'}}>selectable</Text> if
+  //           you click-and-hold.
+  //         </Text>
+  //       </View>
+  //     );
+  //   },
+  // },
+//   {
+//     title: 'Text Decoration',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text
+//             style={{
+//               textDecorationLine: 'underline',
+//               textDecorationStyle: 'solid',
+//             }}>
+//             Solid underline
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'underline',
+//               textDecorationStyle: 'double',
+//               textDecorationColor: '#ff0000',
+//             }}>
+//             Double underline with custom color
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'underline',
+//               textDecorationStyle: 'dashed',
+//               textDecorationColor: '#9CDC40',
+//             }}>
+//             Dashed underline with custom color
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'underline',
+//               textDecorationStyle: 'dotted',
+//               textDecorationColor: 'blue',
+//             }}>
+//             Dotted underline with custom color
+//           </Text>
+//           <Text style={{textDecorationLine: 'none'}}>None textDecoration</Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'line-through',
+//               textDecorationStyle: 'solid',
+//             }}>
+//             Solid line-through
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'line-through',
+//               textDecorationStyle: 'double',
+//               textDecorationColor: '#ff0000',
+//             }}>
+//             Double line-through with custom color
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'line-through',
+//               textDecorationStyle: 'dashed',
+//               textDecorationColor: '#9CDC40',
+//             }}>
+//             Dashed line-through with custom color
+//           </Text>
+//           <Text
+//             style={{
+//               textDecorationLine: 'line-through',
+//               textDecorationStyle: 'dotted',
+//               textDecorationColor: 'blue',
+//             }}>
+//             Dotted line-through with custom color
+//           </Text>
+//           <Text style={{textDecorationLine: 'underline line-through'}}>
+//             Both underline and line-through
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Nested',
+//     description:
+//       'Nested text components will inherit the styles of their ' +
+//       'parents (only backgroundColor is inherited from non-Text parents).  ' +
+//       '<Text> only supports other <Text> and raw text (strings) as children.',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text>
+//             (Normal text,
+//             <Text style={{fontWeight: 'bold'}}>
+//               (and bold
+//               <Text style={{fontSize: 11, color: '#527fe4'}}>
+//                 (and tiny inherited bold blue)
+//               </Text>
+//               )
+//             </Text>
+//             )
+//           </Text>
+//           <Text style={{opacity: 0.7}}>
+//             (opacity
+//             <Text>
+//               (is inherited
+//               <Text style={{opacity: 0.7}}>
+//                 (and accumulated
+//                 <Text style={{backgroundColor: '#ffaaaa'}}>
+//                   (and also applies to the background)
+//                 </Text>
+//                 )
+//               </Text>
+//               )
+//             </Text>
+//             )
+//           </Text>
+//           <Text style={{fontSize: 12}}>
+//             <Entity>Entity Name</Entity>
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+
+//   /* Slow example to load in, but does run in the end. */
+//   {
+//     title: 'Text Align',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text>auto (default) - english LTR</Text>
+//           <Text>
+//             {'\u0623\u062D\u0628 \u0627\u0644\u0644\u063A\u0629 ' +
+//               '\u0627\u0644\u0639\u0631\u0628\u064A\u0629 auto (default) - arabic ' +
+//               'RTL'}
+//           </Text>
+//           <Text style={{textAlign: 'left'}}>
+//             left left left left left left left left left left left left left
+//             left left
+//           </Text>
+//           <Text style={{textAlign: 'center'}}>
+//             center center center center center center center center center
+//             center center
+//           </Text>
+//           <Text style={{textAlign: 'right'}}>
+//             right right right right right right right right right right right
+//             right right
+//           </Text>
+//           <Text style={{textAlign: 'justify'}}>
+//             justify: this text component{"'"}s contents are laid out with
+//             "textAlign: justify" and as you can see all of the lines except the
+//             last one span the available width of the parent container.
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Letter Spacing',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text style={{letterSpacing: 0}}>letterSpacing = 0</Text>
+//           <Text style={{letterSpacing: 2, marginTop: 5}}>
+//             letterSpacing = 2
+//           </Text>
+//           <Text style={{letterSpacing: 9, marginTop: 5}}>
+//             letterSpacing = 9
+//           </Text>
+//           <View style={{flexDirection: 'row'}}>
+//             <Text
+//               style={{
+//                 fontSize: 12,
+//                 letterSpacing: 2,
+//                 backgroundColor: 'fuchsia',
+//                 marginTop: 5,
+//               }}>
+//               With size and background color
+//             </Text>
+//           </View>
+//           <Text style={{letterSpacing: -1, marginTop: 5}}>
+//             letterSpacing = -1
+//           </Text>
+//           <Text
+//             style={{
+//               letterSpacing: 3,
+//               backgroundColor: '#dddddd',
+//               marginTop: 5,
+//             }}>
+//             [letterSpacing = 3]
+//             <Text style={{letterSpacing: 0, backgroundColor: '#bbbbbb'}}>
+//               [Nested letterSpacing = 0]
+//             </Text>
+//             <Text style={{letterSpacing: 6, backgroundColor: '#eeeeee'}}>
+//               [Nested letterSpacing = 6]
+//             </Text>
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Spaces',
+//     render: function() {
+//       return (
+//         <Text>
+//           A {'generated'} {'string'} and some &nbsp;&nbsp;&nbsp; spaces
+//         </Text>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Line Height',
+//     render: function() {
+//       return (
+//         <Text>
+//           <Text style={{lineHeight: 35}}>
+//             A lot of space between the lines of this long passage that should
+//             wrap once.
+//           </Text>
+//         </Text>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Empty Text',
+//     description: "It's ok to have Text with zero or null children.",
+//     render: function() {
+//       return <Text />;
+//     },
+//   },
+//   {
+//     title: 'Toggling Attributes',
+//     render: function(): React.ReactElement<any> {
+//       return <AttributeToggler />;
+//     },
+//   },
+//   /* Very slow to load, but does run */
+//   {
+//     title: 'backgroundColor attribute',
+//     description: 'backgroundColor is inherited from all types of views.',
+//     render: function() {
+//       return (
+//         <Text style={{backgroundColor: 'yellow'}}>
+//           Yellow container background,
+//           <Text style={{backgroundColor: '#ffaaaa'}}>
+//             {' '}
+//             red background,
+//             <Text style={{backgroundColor: '#aaaaff'}}>
+//               {' '}
+//               blue background,
+//               <Text>
+//                 {' '}
+//                 inherited blue background,
+//                 <Text style={{backgroundColor: '#aaffaa'}}>
+//                   {' '}
+//                   nested green background.
+//                 </Text>
+//               </Text>
+//             </Text>
+//           </Text>
+//         </Text>
+//       );
+//     },
+//   },
+//   {
+//     title: 'numberOfLines attribute',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text numberOfLines={1}>
+//             Maximum of one line, no matter how much I write here. If I keep
+//             writing, it{"'"}ll just truncate after one line.
+//           </Text>
+//           <Text numberOfLines={2} style={{marginTop: 20}}>
+//             Maximum of two lines, no matter how much I write here. If I keep
+//             writing, it{"'"}ll just truncate after two lines.
+//           </Text>
+//           <Text style={{marginTop: 20}}>
+//             No maximum lines specified, no matter how much I write here. If I
+//             keep writing, it{"'"}ll just keep going and going.
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Text highlighting (tap the link to see highlight)',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text>
+//             Lorem ipsum dolor sit amet,{' '}
+//             <Text
+//               suppressHighlighting={false}
+//               style={{
+//                 backgroundColor: 'white',
+//                 textDecorationLine: 'underline',
+//                 color: 'blue',
+//               }}
+//               onPress={() => null}>
+//               consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+//               labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+//               nostrud
+//             </Text>{' '}
+//             exercitation ullamco laboris nisi ut aliquip ex ea commodo
+//             consequat.
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'allowFontScaling attribute',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text>
+//             By default, text will respect Text Size accessibility setting on
+//             iOS. It means that all font sizes will be increased or decreased
+//             depending on the value of Text Size setting in{' '}
+//             <Text style={{fontWeight: 'bold'}}>
+//               Settings.app - Display & Brightness - Text Size
+//             </Text>
+//           </Text>
+//           <Text style={{marginTop: 10}}>
+//             You can disable scaling for your Text component by passing {'"'}
+//             allowFontScaling={'{'}false{'}"'} prop.
+//           </Text>
+//           <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
+//             This text will not scale.{' '}
+//             <Text style={{fontSize: 15}}>
+//               This text also won't scale because it inherits "allowFontScaling"
+//               from its parent.
+//             </Text>
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+// //   {
+// //     title: 'Inline views',
+// //     render: () => <TextInlineView.Basic />,
+// //   },
+// //   {
+// //     title: 'Inline image/view clipped by <Text>',
+// //     render: () => <TextInlineView.ClippedByText />,
+// //   },
+// //   {
+// //     title: 'Relayout inline image',
+// //     render: () => <TextInlineView.ChangeImageSize />,
+// //   },
+// //   {
+// //     title: 'Relayout inline view',
+// //     render: () => <TextInlineView.ChangeViewSize />,
+// //   },
+// //   {
+// //     title: 'Relayout nested inline view',
+// //     render: () => <TextInlineView.ChangeInnerViewSize />,
+// //   },
+//   {
+//     title: 'Text shadow',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text
+//             style={{
+//               fontSize: 20,
+//               textShadowOffset: {width: 2, height: 2},
+//               textShadowRadius: 1,
+//               textShadowColor: '#00cccc',
+//             }}>
+//             Demo text shadow
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Ellipsize mode',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text numberOfLines={1}>
+//             This very long text should be truncated with dots in the end.
+//           </Text>
+//           <Text ellipsizeMode="middle" numberOfLines={1}>
+//             This very long text should be truncated with dots in the middle.
+//           </Text>
+//           <Text ellipsizeMode="head" numberOfLines={1}>
+//             This very long text should be truncated with dots in the beginning.
+//           </Text>
+//           <Text ellipsizeMode="clip" numberOfLines={1}>
+//             This very looooooooooooooooooooooooooooong text should be clipped.
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: 'Font variants',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text style={{fontVariant: ['small-caps']}}>Small Caps{'\n'}</Text>
+//           <Text
+//             style={{
+//               fontFamily: Platform.isTV ? 'Times' : 'Hoefler Text',
+//               fontVariant: ['oldstyle-nums'],
+//             }}>
+//             Old Style nums 0123456789{'\n'}
+//           </Text>
+//           <Text
+//             style={{
+//               fontFamily: Platform.isTV ? 'Times' : 'Hoefler Text',
+//               fontVariant: ['lining-nums'],
+//             }}>
+//             Lining nums 0123456789{'\n'}
+//           </Text>
+//           <Text style={{fontVariant: ['tabular-nums']}}>
+//             Tabular nums{'\n'}
+//             1111{'\n'}
+//             2222{'\n'}
+//           </Text>
+//           <Text style={{fontVariant: ['proportional-nums']}}>
+//             Proportional nums{'\n'}
+//             1111{'\n'}
+//             2222{'\n'}
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+// //   {
+// //     title: 'Nested content',
+// //     render: function() {
+// //       // iOS-only because it relies on inline views being able to size to content.
+// //       // Android's implementation requires that a width and height be specified
+// //       // on the inline view.
+// //       return (
+// //         <Text>
+// //           This text has a view
+// //           <InlineView style={{borderColor: 'red', borderWidth: 1}}>
+// //             <Text style={{borderColor: 'blue', borderWidth: 1}}>which has</Text>
+// //             <Text style={{borderColor: 'green', borderWidth: 1}}>
+// //               another text inside.
+// //             </Text>
+// //             <Text style={{borderColor: 'yellow', borderWidth: 1}}>
+// //               And moreover, it has another view
+// //               <InlineView style={{borderColor: 'red', borderWidth: 1}}>
+// //                 <Text style={{borderColor: 'blue', borderWidth: 1}}>
+// //                   with another text inside!
+// //                 </Text>
+// //               </InlineView>
+// //             </Text>
+// //           </InlineView>
+// //           Because we need to go deeper.
+// //         </Text>
+// //       );
+// //     },
+// //   },
+// //   {
+// //     title: 'Dynamic Font Size Adjustment',
+// //     render: function(): React.ReactElement<any> {
+// //       return <AdjustingFontSize />;
+// //     },
+// //   },
+//   {
+//     title: 'Text Align with RTL',
+//     render: function() {
+//       return <TextAlignRTLExample />;
+//     },
+//   },
+//   {
+//     title: 'Transform',
+//     render: function() {
+//       return (
+//         <View>
+//           <Text style={{textTransform: 'uppercase'}}>
+//             This text should be uppercased.
+//           </Text>
+//           <Text style={{textTransform: 'lowercase'}}>
+//             This TEXT SHOULD be lowercased.
+//           </Text>
+//           <Text style={{textTransform: 'capitalize'}}>
+//             This text should be CAPITALIZED.
+//           </Text>
+//           <Text style={{textTransform: 'capitalize'}}>
+//             Mixed: <Text style={{textTransform: 'uppercase'}}>uppercase </Text>
+//             <Text style={{textTransform: 'lowercase'}}>LoWeRcAsE </Text>
+//             <Text style={{textTransform: 'capitalize'}}>
+//               capitalize each word
+//             </Text>
+//           </Text>
+//           <Text>
+//             Should be "ABC":
+//             <Text style={{textTransform: 'uppercase'}}>
+//               a<Text>b</Text>c
+//             </Text>
+//           </Text>
+//           <Text>
+//             Should be "AbC":
+//             <Text style={{textTransform: 'uppercase'}}>
+//               a<Text style={{textTransform: 'none'}}>b</Text>c
+//             </Text>
+//           </Text>
+//         </View>
+//       );
+//     },
+//   },
+//   {
+//     title: "Text `alignItems: 'baseline'` style",
+//     render: function() {
+//       return <TextBaseLineLayoutExample />;
+//     },
+//   },
+];

--- a/apps/demo-react/src/RNTesterExamples/Text.tsx
+++ b/apps/demo-react/src/RNTesterExamples/Text.tsx
@@ -12,6 +12,7 @@
 
 import * as React from "react";
 import { View, Text, TextInput, Button, TextProps } from "@triniwiz/nativescript-yogalayout/react";
+import type { Example } from "./ExampleList";
 
 const Platform = {
   isTV: false
@@ -469,7 +470,6 @@ class TextWithCapBaseBox extends React.Component<
 export const title: string = '<Text>';
 export const description: string = 'Base component for rendering styled text.';
 export const displayName: string = 'TextExample';
-type Example = { title: string, description?: string, render: () => any };
 export const examples: Example[] = [
   {
     title: 'Wrap',

--- a/apps/demo-react/src/RNTesterExamples/View.tsx
+++ b/apps/demo-react/src/RNTesterExamples/View.tsx
@@ -1,0 +1,495 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+import * as React from "react";
+import { View, Text, TextInput, Button } from "@triniwiz/nativescript-yogalayout/react";
+
+/*
+Differences seen in here:
+
+- Style can be an array in RN
+- Style is made by StyleSheet
+- StyleSheet.hairlineWidth
+- TouchableWithoutFeedback doesn't exist in NS
+- needsOffscreenAlphaCompositing doesn't exist in NS
+- overflow doesn't exist in NS
+- left, top, (right?), (bottom?) can be set through Style in RN, but not NS
+- left, top, (right?), (bottom?) only exist on main props rather than Styles
+- StyleSheet.absoluteFill may be impossible to achieve on RCTFlexboxLayout, as it's an absolute layout concept..?
+- lengths are specified as Length objects in NS rather than simply as strings (if abiding by typings)
+- colors are specified as Color objects in NS rather than simply as strings (if abiding by typings)
+- View -> RCTFlexboxLayout (but with flexDirection 'column' as default)
+- Text -> label or RCTTextView
+*/
+
+export const title: string = '<View>';
+export const description: string =
+  'Basic building block of all UI, examples that ' +
+  'demonstrate some of the many styles available.';
+
+export const displayName: string = 'ViewExample';
+type Example = { title: string, description?: string, render: () => any };
+
+export const examples: Example[] = [
+  {
+    title: 'Background Color',
+    render() {
+      return (
+        <View style={{backgroundColor: '#527FE4', padding: 5}}>
+          <label style={{fontSize: 11}}>Blue background</label>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Border',
+    render() {
+      return (
+        <View style={{borderColor: '#527FE4', borderWidth: 5, padding: 10}}>
+          <label style={{fontSize: 11}}>5px blue border</label>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Padding/Margin',
+    render() {
+      const styles = {
+        box: {
+          backgroundColor: '#527FE4',
+          borderColor: '#000033',
+          borderWidth: 1,
+        },
+      };
+      return (
+        <View style={{borderColor: '#bb0000', borderWidth: 0.5}}>
+          <View style={{ ...styles.box, padding: 5}}>
+            <label style={{fontSize: 11}}>5px padding</label>
+          </View>
+          <View style={{ ...styles.box, margin: 5}}>
+            <label style={{fontSize: 11}}>5px margin</label>
+          </View>
+          <View
+            style={
+              { ...styles.box, margin: 5, padding: 5, alignSelf: 'flex-start'}
+            }>
+            <label style={{fontSize: 11}}>5px margin and padding,</label>
+            <label style={{fontSize: 11}}>widthAutonomous=true</label>
+          </View>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Border Radius',
+    render() {
+      return (
+        <View style={{borderWidth: 0.5, borderRadius: 5, padding: 5}}>
+          <label style={{fontSize: 11}}>
+            Too much use of `borderRadius` (especially large radii) on anything
+            which is scrolling may result in dropped frames. Use sparingly.
+          </label>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Border Style',
+    render() {
+      type Props = {};
+      type State = {
+        showBorder: boolean,
+      };
+
+      class ViewBorderStyleExample extends React.Component<Props, State> {
+        state = {
+          showBorder: true,
+        };
+
+        render() {
+          return (
+            <View onTap={this._handlePress}>
+              <View>
+                <View
+                  style={
+                    {
+                      borderWidth: 1,
+                      padding: 5,
+                        ...(this.state.showBorder
+                        ? {
+                            borderStyle: 'dashed',
+                          }
+                        : {})
+                    }}>
+                  <label style={{fontSize: 11}}>Dashed border style</label>
+                </View>
+                <View
+                  style={{
+                      marginTop: 5,
+                      borderWidth: 1,
+                      borderRadius: 5,
+                      padding: 5,
+                      ...(this.state.showBorder
+                        ? {
+                            borderStyle: 'dotted',
+                          }
+                        : {})
+                    }}>
+                  <label style={{fontSize: 11}}>Dotted border style</label>
+                </View>
+              </View>
+            </View>
+          );
+        }
+
+        _handlePress = () => {
+          this.setState({showBorder: !this.state.showBorder});
+        };
+      }
+      return <ViewBorderStyleExample />;
+    },
+  },
+  {
+    title: 'Circle with Border Radius',
+    render() {
+      return (
+        <View
+          style={{borderRadius: 10, borderWidth: 1, width: 20, height: 20}}
+        />
+      );
+    },
+  },
+  /* Doesn't translate well to NativeScript */
+//   {
+//     title: 'Overflow',
+//     render() {
+//       const StyleSheet = {
+//           absoluteFill: {
+//               // position: 'absolute' as 'absolute',
+//               left: { value: 0, unit: "px" as "px" } as Length,
+//               // right: { value: 0, unit: "px" as "px" } as Length,
+//               top: { value: 0, unit: "px" as "px" } as Length,
+//               // bottom: { value: 0, unit: "px" as "px" } as Length,
+//           }
+//       };
+//       const styles = {
+//         container: {
+//           // borderWidth: StyleSheet.hairlineWidth,
+//           borderWidth: 1,
+//           height: { value: 12, unit: "px" as "px" },
+//           marginBottom: 8,
+//           marginEnd: 16,
+//           width: { value: 95, unit: "px" as "px" },
+//         },
+//         content: {
+//           height: { value: 20, unit: "px" as "px" },
+//           width: { value: 200, unit: "px" as "px" },
+//         },
+//       };
+
+//       // NOTE: The <View> that sets `overflow` should only have other layout
+//       // styles so that we can accurately test view flattening optimizations.
+//       return (
+//         <View style={{flexDirection: 'row'}}>
+//           <View style={styles.container}>
+//             <View {...StyleSheet.absoluteFill}>
+//               <label style={styles.content}>undefined</label>
+//             </View>
+//           </View>
+//           <View style={styles.container}>
+//             <View {...StyleSheet.absoluteFill} style={{ overflow: 'hidden'}}>
+//               <label style={styles.content}>hidden</label>
+//             </View>
+//           </View>
+//           <View style={styles.container}>
+//             <View {...StyleSheet.absoluteFill} style={{ overflow: 'visible'}}>
+//               <label style={styles.content}>visible</label>
+//             </View>
+//           </View>
+//         </View>
+//       );
+//     },
+//   },
+  {
+    title: 'Opacity',
+    render() {
+      return (
+        <View>
+          <View style={{opacity: 0}}>
+            <label>Opacity 0</label>
+          </View>
+          <View style={{opacity: 0.1}}>
+            <label>Opacity 0.1</label>
+          </View>
+          <View style={{opacity: 0.3}}>
+            <label>Opacity 0.3</label>
+          </View>
+          <View style={{opacity: 0.5}}>
+            <label>Opacity 0.5</label>
+          </View>
+          <View style={{opacity: 0.7}}>
+            <label>Opacity 0.7</label>
+          </View>
+          <View style={{opacity: 0.9}}>
+            <label>Opacity 0.9</label>
+          </View>
+          <View style={{opacity: 1}}>
+            <label>Opacity 1</label>
+          </View>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Offscreen Alpha Compositing',
+    render() {
+      type Props = {};
+      type State = {
+        active: boolean,
+      };
+
+      const styles = {
+        alphaCompositing: {
+          justifyContent: 'space-around' as 'space-around',
+          width: { value: 100, unit: "px" as "px" },
+          height: { value: 50, unit: "px" as "px" },
+          borderRadius: 100,
+        },
+      };
+
+      class OffscreenAlphaCompositing extends React.Component<Props, State> {
+        state = {
+          active: false,
+        };
+
+        render() {
+          return (
+            /* TouchableWithoutFeedback */
+            <View onTap={this._handlePress}>
+              <View>
+                <label style={{paddingBottom: 10}}>Blobs</label>
+                <View
+                  style={{opacity: 1.0, paddingBottom: 30}}
+                  /* Doesn't exist in NativeScript */
+                  // needsOffscreenAlphaCompositing={this.state.active}
+                  >
+                  <View
+                    style={{
+                      marginTop: 0, marginLeft: 0, backgroundColor: '#FF6F59', ...styles.alphaCompositing,
+                    }}
+                  />
+                  <View
+                    style={
+                      {
+                        ...styles.alphaCompositing,
+                        marginTop: -50,
+                        marginLeft: 50,
+                        backgroundColor: '#F7CB15',
+                      }}
+                  />
+                </View>
+                <label style={{paddingBottom: 10}}>
+                  Same blobs, but their shared container have 0.5 opacity
+                </label>
+                <label style={{paddingBottom: 10}}>
+                  Tap to {this.state.active ? 'activate' : 'deactivate'}{' '}
+                  needsOffscreenAlphaCompositing
+                </label>
+                <View
+                  style={{opacity: 0.8}}
+                  /* Doesn't exist in NativeScript */
+                  // needsOffscreenAlphaCompositing={this.state.active}
+                >
+                  <View
+                    style={
+                      { marginTop: 0, marginLeft: 0, backgroundColor: '#FF6F59', ...styles.alphaCompositing, }
+                    }
+                  />
+                  <View
+                    style={
+                      {
+                        marginTop: -50,
+                        marginLeft: 50,
+                        backgroundColor: '#F7CB15',
+                        ...styles.alphaCompositing,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          );
+        }
+
+        _handlePress = () => {
+          this.setState({active: !this.state.active});
+        };
+      }
+
+      return <OffscreenAlphaCompositing />;
+    },
+  },
+  {
+    title: 'ZIndex',
+    render() {
+      type Props = {};
+      type State = {
+        flipped: boolean,
+      };
+
+      const styles = {
+        zIndex: {
+          justifyContent: 'space-around' as 'space-around',
+          width: { value: 100, unit: "px" as "px" },
+          height: { value: 50, unit: "px" as "px" },
+          marginTop: -10,
+        },
+      };
+
+      class ZIndexExample extends React.Component<Props, State> {
+        state = {
+          flipped: false,
+        };
+
+        render() {
+          const indices = this.state.flipped ? [-1, 0, 1, 2] : [2, 1, 0, -1];
+          return (
+            /* TouchableWithoutFeedback */
+            <View onTap={this._handlePress}>
+              <View>
+                <label style={{paddingBottom: 10}}>
+                  Tap to flip sorting order
+                </label>
+                <View
+                  style={
+                    {
+                      marginTop: 0,
+                      backgroundColor: '#E57373',
+                      zIndex: indices[0],
+                      ...styles.zIndex,
+                    }
+                  }>
+                  <label>ZIndex {indices[0]}</label>
+                </View>
+                <View
+                  style={
+                    {
+                      marginLeft: 50,
+                      backgroundColor: '#FFF176',
+                      zIndex: indices[1],
+                      ...styles.zIndex,
+                    }
+                  }>
+                  <label>ZIndex {indices[1]}</label>
+                </View>
+                <View
+                  style={
+                    {
+                      marginLeft: 100,
+                      backgroundColor: '#81C784',
+                      zIndex: indices[2],
+                      ...styles.zIndex,
+                    }
+                  }>
+                  <label>ZIndex {indices[2]}</label>
+                </View>
+                <View
+                  style={
+                    {
+                      marginLeft: 150,
+                      backgroundColor: '#64B5F6',
+                      zIndex: indices[3],
+                      ...styles.zIndex,
+                    }
+                  }>
+                  <label>ZIndex {indices[3]}</label>
+                </View>
+              </View>
+            </View>
+          );
+        }
+
+        _handlePress = () => {
+          this.setState({flipped: !this.state.flipped});
+        };
+      }
+      return <ZIndexExample />;
+    },
+  },
+  /* BackfaceVisibility Doesn't exist in NS! */
+//   {
+//     title: 'BackfaceVisibility',
+//     render: function() {
+//       return (
+//         <>
+//           <label style={{paddingBottom: 10}}>
+//             View #1, front is visible, back is hidden.
+//           </label>
+//           <View style={{justifyContent: 'center', alignItems: 'center'}}>
+//             <View
+//               style={{
+//                 height: 200,
+//                 width: 200,
+//                 justifyContent: 'center',
+//                 alignItems: 'center',
+//                 backgroundColor: 'blue',
+//                 backfaceVisibility: 'hidden',
+//               }}>
+//               <label>Front</label>
+//             </View>
+//             <View
+//               style={{
+//                 height: 200,
+//                 width: 200,
+//                 justifyContent: 'center',
+//                 alignItems: 'center',
+//                 backgroundColor: 'red',
+//                 backfaceVisibility: 'hidden',
+//                 transform: [{rotateY: '180deg'}],
+//                 position: 'absolute',
+//                 top: 0,
+//               }}>
+//               <label>Back (You should not see this)</label>
+//             </View>
+//           </View>
+//           <label style={{paddingTop: 10, paddingBottom: 10}}>
+//             View #2, front is hidden, back is visible.
+//           </label>
+//           <View style={{justifyContent: 'center', alignItems: 'center'}}>
+//             <View
+//               style={{
+//                 height: 200,
+//                 width: 200,
+//                 justifyContent: 'center',
+//                 alignItems: 'center',
+//                 backgroundColor: 'blue',
+//                 backfaceVisibility: 'hidden',
+//               }}>
+//               <label>Front (You should not see this)</label>
+//             </View>
+//             <View
+//               style={{
+//                 height: 200,
+//                 width: 200,
+//                 justifyContent: 'center',
+//                 alignItems: 'center',
+//                 backgroundColor: 'red',
+//                 backfaceVisibility: 'hidden',
+//                 position: 'absolute',
+//                 top: 0,
+//               }}>
+//               <label>Back</label>
+//             </View>
+//           </View>
+//         </>
+//       );
+//     },
+//   },
+];

--- a/apps/demo-react/src/components/AppContainer.tsx
+++ b/apps/demo-react/src/components/AppContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ItemEventData } from '@nativescript/core';
 import { ListView } from 'react-nativescript';
 import { YogaLayout } from './YogaLayout';
+import { ViewExample } from './View';
 
 interface MyItem {
     text: string;
@@ -12,6 +13,10 @@ const items: MyItem[] = [
     {
         text: 'YogaLayout',
         component: YogaLayout,
+    },
+    {
+        text: 'View',
+        component: ViewExample,
     },
 ];
 

--- a/apps/demo-react/src/components/AppContainer.tsx
+++ b/apps/demo-react/src/components/AppContainer.tsx
@@ -23,7 +23,7 @@ const items: MyItem[] = [
     },
     {
         text: 'RNTester: Text',
-        component: () => (<ExampleList examples={textExamples}/>),
+        component: () => (<ExampleList examples={textExamples.slice(0, 6)}/>),
     },
     {
         text: 'RNTester: Button',

--- a/apps/demo-react/src/components/AppContainer.tsx
+++ b/apps/demo-react/src/components/AppContainer.tsx
@@ -23,15 +23,11 @@ const items: MyItem[] = [
     },
     {
         text: 'RNTester: Text',
-        component: function(){
-            return (<ExampleList examples={textExamples}/>);
-        },
+        component: () => (<ExampleList examples={textExamples}/>),
     },
     {
         text: 'RNTester: Button',
-        component: function(){
-            return (<ExampleList examples={buttonExamples}/>);
-        },
+        component: () => (<ExampleList examples={buttonExamples}/>),
     },
 ];
 

--- a/apps/demo-react/src/components/AppContainer.tsx
+++ b/apps/demo-react/src/components/AppContainer.tsx
@@ -3,6 +3,9 @@ import { ItemEventData } from '@nativescript/core';
 import { ListView } from 'react-nativescript';
 import { YogaLayout } from './YogaLayout';
 import { ViewExample } from './View';
+import { ExampleList } from '../RNTesterExamples/ExampleList';
+import { examples as textExamples } from '../RNTesterExamples/Text';
+import { examples as buttonExamples } from '../RNTesterExamples/Button';
 
 interface MyItem {
     text: string;
@@ -17,6 +20,18 @@ const items: MyItem[] = [
     {
         text: 'View',
         component: ViewExample,
+    },
+    {
+        text: 'RNTester: Text',
+        component: function(){
+            return (<ExampleList examples={textExamples}/>);
+        },
+    },
+    {
+        text: 'RNTester: Button',
+        component: function(){
+            return (<ExampleList examples={buttonExamples}/>);
+        },
     },
 ];
 

--- a/apps/demo-react/src/components/AppContainer.tsx
+++ b/apps/demo-react/src/components/AppContainer.tsx
@@ -4,6 +4,7 @@ import { ListView } from 'react-nativescript';
 import { YogaLayout } from './YogaLayout';
 import { ViewExample } from './View';
 import { ExampleList } from '../RNTesterExamples/ExampleList';
+import { examples as viewExamples } from '../RNTesterExamples/View';
 import { examples as textExamples } from '../RNTesterExamples/Text';
 import { examples as buttonExamples } from '../RNTesterExamples/Button';
 
@@ -22,7 +23,19 @@ const items: MyItem[] = [
         component: ViewExample,
     },
     {
+        text: 'RNTester: View',
+        /**
+         * We slice down to 12 examples because – as to my understanding – YogaLayout doesn't support "auto" height,
+         * the examples just shrink and don't reserve any height for themselves. Thus, we don't get a scrolling list
+         * of tests and they just get smaller and smaller until NativeScript can't solve the layout and stalls.
+         */
+        component: () => (<ExampleList examples={viewExamples.slice(0, 12)}/>),
+    },
+    {
         text: 'RNTester: Text',
+        /**
+         * Again, we slice down to 6 examples for the same reason as above.
+         */
         component: () => (<ExampleList examples={textExamples.slice(0, 6)}/>),
     },
     {

--- a/apps/demo-react/src/components/View.tsx
+++ b/apps/demo-react/src/components/View.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { View } from "@triniwiz/nativescript-yogalayout/react";
+
+export function ViewExample() {
+    return (
+        <View>
+            <View
+                style={{
+                    backgroundColor: "aqua",
+                    margin: 50,
+                    padding: 30,
+                    borderRadius: 10,
+                    borderWidth: 5,
+                    borderColor: "purple",
+                }}
+            >
+                <View
+                    style={{
+                        backgroundColor: "red",
+                        padding: 2,
+                    }}
+                >
+                    <View
+                        style={{
+                            flex: 0.3,
+                            backgroundColor: "green",
+                        }}
+                    >
+                        <label alignSelf="center" color="black" text="First"/>
+                    </View>
+                    <View
+                        style={{
+                            flex: 0.5,
+                            backgroundColor: "white",
+                        }}
+                    >
+                        <label alignSelf="center" color="black" text="Second"/>
+                    </View>
+                    <View
+                        style={{ backgroundColor: "pink" }}
+                    >
+                        <label alignSelf="center" color="black" text="Third"/>
+                    </View>
+                    <label alignSelf="center" color="blue" text="Something"/>
+                </View>
+                <View
+                    style={{
+                        position: "absolute",
+                        bottom: 10,
+                        right: 10,
+                        width: 100,
+                        height: 100,
+                        backgroundColor: "yellow",
+                        padding: 10,
+                    }}
+                >
+                    <label color="black" text="Absolute"/>
+                </View>
+            </View>
+            {/* 
+            <View position="absolute" top={0} left={0} width={200} height={200} backgroundColor="yellow" padding={10}>
+                <textField text="{{ flex }}"/>
+                <slider loaded="{{ sliderLoaded }}"/>
+            </View>
+            */}
+        </View>
+    );
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"ng-packagr": "~10.1.0",
 		"patch-package": "^6.4.7",
 		"react": "~16.13.1",
-		"react-nativescript": "^3.0.0-beta.2",
+		"react-nativescript": "^3.0.0-beta.3",
 		"rxjs": "~6.6.0",
 		"svelte": "3.24.1",
 		"svelte-native": "0.9.0-alpha",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"ng-packagr": "~10.1.0",
 		"patch-package": "^6.4.7",
 		"react": "~16.13.1",
-		"react-nativescript": "^3.0.0-beta.1",
+		"react-nativescript": "^3.0.0-beta.2",
 		"rxjs": "~6.6.0",
 		"svelte": "3.24.1",
 		"svelte-native": "0.9.0-alpha",

--- a/packages/nativescript-yogalayout/react/Button.tsx
+++ b/packages/nativescript-yogalayout/react/Button.tsx
@@ -1,0 +1,25 @@
+/// <reference path="./index.ts" />
+
+import * as React from "react";
+import { mapEventHandlersRNToRNS } from "./ReactNativeCompat";
+import { Button as NSButton } from "@nativescript/core";
+import { ButtonAttributes, NativeScriptProps } from "react-nativescript";
+import { RNOnlyTextProps } from "./Text";
+
+/**
+ * Note: Does NOT extend YogaProps, even in React Native. The idea is that it's to be used almost like a
+ * text node, with all layout handled by the parent. It also does not support 'style' in React Native.
+ * 
+ * Under-the-hood, I've implemented it as a TextView, so it's easiest just to extend TextViewAttributes.
+ * These props are filled in primarily for API compatibility with React Native's text component.
+ * In any cases where the feature does not exist in NativeScript, we accept the prop but no-op.
+ */
+export interface RNButtonProps extends Omit<NativeScriptProps<ButtonAttributes, NSButton>, "style">, RNOnlyTextProps {
+    title: string;
+}
+
+export function Button(props: RNButtonProps){
+    const { onPress, title, ...otherProps } = props;
+
+    return (<button text={title} {...mapEventHandlersRNToRNS(otherProps)}/>);
+};

--- a/packages/nativescript-yogalayout/react/Button.tsx
+++ b/packages/nativescript-yogalayout/react/Button.tsx
@@ -21,5 +21,5 @@ export interface RNButtonProps extends Omit<NativeScriptProps<ButtonAttributes, 
 export function Button(props: RNButtonProps){
     const { onPress, title, ...otherProps } = props;
 
-    return (<button text={title} {...mapEventHandlersRNToRNS(otherProps)}/>);
+    return (<button color="black" text={title} {...mapEventHandlersRNToRNS(otherProps)}/>);
 };

--- a/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
+++ b/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
@@ -1,5 +1,6 @@
 import { Color } from "@nativescript/core";
-import { FontWeight } from "@nativescript/core/ui/enums";
+// Conflicts with NativeScript 7 (which this monorepo uses), so we'll use the underlying values of the enum directly instead.
+// import { FontWeight } from "@nativescript/core/ui/enums";
 
 export function mapEventHandlersRNToRNS<T extends {}>(handlers: T): T {
     return Object.keys(handlers).reduce((acc: T, name: string) => {
@@ -38,14 +39,15 @@ export function convertStyleRNToRNS<T extends {}>(styles: T | T[]): T {
 
     return Object.keys(flattenedStyle).reduce((acc: T, name: string) => {
         const mapping = mapStyleRNToRNS(name, flattenedStyle[name]);
-        delete flattenedStyle[name];
-        if(mapping === null) return acc; // Explicitly not supported.
+        if(mapping === null){
+            return acc; // Explicitly not supported.
+        }
 
         Object.keys(mapping).forEach((key: string) => {
-            flattenedStyle[key] = mapping[key];
+            acc[key] = mapping[key];
         });
         return acc;
-    }, flattenedStyle);
+    }, {} as T);
 }
 
 export function flattenStyle<T extends {}>(styles: T | T[]): T {
@@ -65,33 +67,34 @@ export function mapStyleRNToRNS(name: string, value: string): Record<string, any
             switch(value){
                 case "100":
                 case "thin":
-                    fontWeight = FontWeight.thin; // 100
+                    fontWeight = "100"; // FontWeight.thin; // 100
                 case "200":
                 case "extraLight":
-                    fontWeight = FontWeight.extraLight; // 200
+                    fontWeight = "200"; // FontWeight.extraLight; // 200
                 case "300":
                 case "light":
-                    fontWeight = FontWeight.light; // 300
+                    fontWeight = "300"; // FontWeight.light; // 300
                 case "400":
                 case "normal":
-                    fontWeight = FontWeight.normal; // 400
+                    fontWeight = "400"; // FontWeight.normal; // 400
                 case "500":
                 case "medium":
-                    fontWeight = FontWeight.medium; // 500
+                    fontWeight = "500"; // FontWeight.medium; // 500
                 case "600":
                 case "semiBold":
-                    fontWeight = FontWeight.semiBold; // 600
+                    fontWeight = "600"; // FontWeight.semiBold; // 600
                 case "700":
                 case "bold":
-                    fontWeight = FontWeight.bold; // 700
+                    fontWeight = "700"; // FontWeight.bold; // 700
                 case "800":
                 case "extraBold":
-                    fontWeight = FontWeight.extraBold; // 800
+                    fontWeight = "800"; // FontWeight.extraBold; // 800
                 case "900":
                 case "black":
-                    fontWeight = FontWeight.black; // 900
+                    fontWeight = "900"; // FontWeight.black; // 900
                 default:
-                    fontWeight = FontWeight.normal; // I don't have the motivation to support in-between values.
+                    // Here we don't support in-between values, but I think they're disallowed in RN and CSS anyway.
+                    fontWeight = "400"; // FontWeight.normal;
             }
             return { [name]: fontWeight };
         case "textAlign": {

--- a/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
+++ b/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
@@ -63,6 +63,9 @@ export function mapStyleRNToRNS(name: string, value: string): Record<string, any
         case "fontVariant":
             return null;
         case "fontWeight":
+            /**
+             * FIXME: Migrate to FontWeight enum once monorepo is using NativeScript 8 for this package.
+             */
             let fontWeight;
             switch(value){
                 case "100":

--- a/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
+++ b/packages/nativescript-yogalayout/react/ReactNativeCompat.ts
@@ -1,0 +1,173 @@
+import { Color } from "@nativescript/core";
+import { FontWeight } from "@nativescript/core/ui/enums";
+
+export function mapEventHandlersRNToRNS<T extends {}>(handlers: T): T {
+    return Object.keys(handlers).reduce((acc: T, name: string) => {
+        const handler = handlers[name];
+        const mappedName = mapEventHandlerNameRNToRNS(name);
+        if(mappedName === null){
+            delete handlers[name];
+            return acc;
+        }
+        if(mappedName === name){
+            return acc;
+        }
+        delete handlers[name];
+        handlers[mappedName] = handler;
+        return acc;
+    }, handlers);
+}
+
+export function mapEventHandlerNameRNToRNS(name: string): string | null {
+    switch(name){
+        case "onPress":
+            return "onTap";
+        case "onTextLayout":
+            // Not supported
+            return null;
+        default:
+            return name;
+    }
+}
+
+export function convertStyleRNToRNS<T extends {}>(styles: T | T[]): T {
+    const flattenedStyle: T = flattenStyle(styles);
+
+    /* Here we shallow-clone the flattened style to avoid any objects sharing the same instance of e.g. FontWeight and Color. */
+    // const style: Partial<PermissiveStyle> = { ...flattenedStyle };
+
+    return Object.keys(flattenedStyle).reduce((acc: T, name: string) => {
+        const mapping = mapStyleRNToRNS(name, flattenedStyle[name]);
+        delete flattenedStyle[name];
+        if(mapping === null) return acc; // Explicitly not supported.
+
+        Object.keys(mapping).forEach((key: string) => {
+            flattenedStyle[key] = mapping[key];
+        });
+        return acc;
+    }, flattenedStyle);
+}
+
+export function flattenStyle<T extends {}>(styles: T | T[]): T {
+    if(!Array.isArray(styles)) return styles;
+    return Object.assign({}, ...styles);
+}
+
+export function mapStyleRNToRNS(name: string, value: string): Record<string, any>|null {
+    switch(name){
+        case "textShadowColor":
+        case "textShadowRadius":
+        case "textShadowOffset":
+        case "fontVariant":
+            return null;
+        case "fontWeight":
+            let fontWeight;
+            switch(value){
+                case "100":
+                case "thin":
+                    fontWeight = FontWeight.thin; // 100
+                case "200":
+                case "extraLight":
+                    fontWeight = FontWeight.extraLight; // 200
+                case "300":
+                case "light":
+                    fontWeight = FontWeight.light; // 300
+                case "400":
+                case "normal":
+                    fontWeight = FontWeight.normal; // 400
+                case "500":
+                case "medium":
+                    fontWeight = FontWeight.medium; // 500
+                case "600":
+                case "semiBold":
+                    fontWeight = FontWeight.semiBold; // 600
+                case "700":
+                case "bold":
+                    fontWeight = FontWeight.bold; // 700
+                case "800":
+                case "extraBold":
+                    fontWeight = FontWeight.extraBold; // 800
+                case "900":
+                case "black":
+                    fontWeight = FontWeight.black; // 900
+                default:
+                    fontWeight = FontWeight.normal; // I don't have the motivation to support in-between values.
+            }
+            return { [name]: fontWeight };
+        case "textAlign": {
+            if(value === "justify" || value === "auto"){
+                // Not supported.
+                return null;
+            }
+            return { "textAlignment": value };
+        }
+        case "textDecorationLine":
+            return { "textDecoration": value };
+        // NativeScript text decorations can't be coloured nor styled, as far as I understand.
+        case "textDecorationStyle":
+        case "textDecorationColor":
+            return null;
+        case "tintColor": // Supported only on Image component
+        case "placeholderColor": // Not supported at all
+            return null;
+        case "color":
+        case "backgroundColor":
+        case "borderTopColor":
+        case "borderRightColor":
+        case "borderBottomColor":
+        case "borderLeftColor":
+        case "tabTextColor":
+        case "tabBackgroundColor":
+        case "selectedTabTextColor":
+        case "androidSelectedTabHighlightColor":
+        case "separatorColor":
+        case "selectedBackgroundColor":
+        case "androidStatusBarBackground": {
+            /**
+             * @see https://facebook.github.io/react-native/docs/colors
+             */
+            if(typeof value === "string" || (value as any) instanceof Color){
+                return { [name]: value };
+            }
+            return null;
+        }
+        case "position":
+        case "direction": // Beware: We don't have a cross-platform API for this yet; it relies upon Obj-C and iOS enums for now. React Native expects "inherit" | "ltr" | "rtl".
+        case "width":
+        case "height":
+        case "marginLeft":
+        case "marginTop":
+        case "marginRight":
+        case "marginBottom":
+        case "borderWidth":
+        case "borderTopWidth":
+        case "borderRightWidth":
+        case "borderBottomWidth":
+        case "borderLeftWidth":
+        case "borderRadius":
+        case "borderTopLeftRadius":
+        case "borderTopRightRadius":
+        case "borderBottomRightRadius":
+        case "borderBottomLeftRadius":
+        case "minWidth":
+        case "minHeight":
+        case "paddingLeft":
+        case "paddingTop":
+        case "paddingRight":
+        case "paddingBottom":
+        case "paddingVertical":
+        case "paddingHorizontal":
+        case "top":
+        case "left":
+        case "right":
+        case "bottom":
+        case "padding":
+        case "margin":
+        case "borderColor":
+        case "borderWidth":
+            return { [name]: value };
+        default:
+            /* We'll see how this goes... */
+            return { [name]: value };
+    }
+}

--- a/packages/nativescript-yogalayout/react/Text.tsx
+++ b/packages/nativescript-yogalayout/react/Text.tsx
@@ -115,7 +115,7 @@ export function Text(props: RNTextProps){
     const styleResolved = style ? convertStyleRNToRNS(style) as RNSStyle & RNOnlyTextStyles : void 0;
 
     return (
-        <textView {...mapEventHandlersRNToRNS(otherProps)} style={styleResolved}>
+        <textView {...mapEventHandlersRNToRNS(otherProps)} {...(styleResolved ? { style: styleResolved } : {})}>
             {children}
         </textView>
     );

--- a/packages/nativescript-yogalayout/react/Text.tsx
+++ b/packages/nativescript-yogalayout/react/Text.tsx
@@ -1,0 +1,122 @@
+/// <reference path="./index.ts" />
+
+import * as React from "react";
+import { RNOnlyViewStyles, View } from "./View";
+import { convertStyleRNToRNS, mapEventHandlersRNToRNS } from "./ReactNativeCompat";
+import { TextView } from "@nativescript/core";
+import { NativeScriptProps, RNSStyle, TextViewAttributes } from "react-nativescript";
+
+export interface RNOnlyTextProps {
+    onPress?: (...args: any[]) => void,
+    onTextLayout?: (...args: any[]) => void,
+    suppressHighlighting?: boolean,
+    allowFontScaling?: boolean,
+    multiline?: boolean,
+    adjustsFontSizeToFit?: boolean,
+    selectable?: boolean,
+    ellipsizeMode?: "tail"|"middle"|"head"|"clip",
+    numberOfLines?: number,
+}
+
+/**
+ * Note: Does NOT extend YogaProps, even in React Native. The idea is that it's to be used almost like a
+ * text node, with all layout handled by the parent. So neither the style nor props inherit from yoga.
+ * 
+ * Under-the-hood, I've implemented it as a TextView, so it's easiest just to extend TextViewAttributes.
+ * These props are filled in primarily for API compatibility with React Native's text component.
+ * In any cases where the feature does not exist in NativeScript, we accept the prop but no-op.
+ */
+export interface RNTextProps extends Omit<NativeScriptProps<TextViewAttributes, TextView>, "style">, RNOnlyTextProps {
+    style?: RNSStyle & RNOnlyTextStyles;
+}
+
+/**
+ * @see https://facebook.github.io/react-native/docs/text.html#style
+ * @see TextStyle in @types/react-native
+ */
+export interface RNOnlyTextStyles extends RNOnlyTextIOSStyles, RNOnlyTextAndroidStyles, RNOnlyViewStyles {
+    textAlign?: "auto" | "initial" | "left" | "center" | "right" | "justify";
+    textDecorationLine?: "none" | "underline" | "line-through" | "underline line-through";
+    textDecorationStyle?: "solid" | "double" | "dashed" | "dotted";
+    textDecorationColor?: string;
+
+    textShadowOffset?: { width: number, height: number };
+    textShadowRadius?: number;
+    textShadowColor?: string;
+}
+
+/**
+ * @see TextStyleIOS in @types/react-native
+ */
+export interface RNOnlyTextIOSStyles {
+    fontVariant?: string[];
+}
+/**
+ * @see TextStyleAndroid in @types/react-native
+ */
+export interface RNOnlyTextAndroidStyles {
+    textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center';
+    includeFontPadding?: boolean;
+}
+
+export function nestTextChildren(children: React.ReactNode, parentProps): React.ReactNode {
+    return React.Children.map(children, function(child: React.ReactNode, i: number){
+        if(typeof child === "string" || typeof child === "number"){
+            // console.log(`[nestTextChildren] ReactText case`);
+            // ReactText case.
+            return (<Text>{child}</Text>);
+        } else if(typeof child === "boolean" || !child){
+            // console.log(`[nestTextChildren] falsy or boolean case`);
+            return child;
+        } else if(Array.isArray(child)){
+            // console.log(`[nestTextChildren] array case`);
+            // ReactFragment case.
+            // FIXME: support
+            return null;
+        }
+
+        // const { children, ...rest } = (child as React.ReactElement).props;
+        // console.log(`[nestTextChildren] default (ReactElement) case, with props`, { ...rest });
+        /* I'm assuming it's ReactElement at this point, but it could still be a ReactPortal | ReactFragment.
+         * May break in such case. */
+        // if((child as React.ReactElement).props){
+        //     Object.assign({}, (child as React.ReactElement).props, { ...parentProps });
+        // }
+        return child;
+    });
+}
+export function Text(props: RNTextProps){
+    const {
+        style,
+        onPress,
+        onTextLayout,
+
+        /* Not supported in {N}? */
+        multiline,
+        suppressHighlighting,
+        allowFontScaling,
+        adjustsFontSizeToFit,
+        selectable,
+        ellipsizeMode,
+        numberOfLines,
+
+        children,
+        ...otherProps
+    } = props;
+
+    /* Here's my very limited support for nesting children inside Text (which I don't like as a pattern anyway...) */
+    if(React.Children.count(children) > 1){
+        return (
+            // RNTester seems to default to row direction in nested texts.
+            <View flexDirection="row">{nestTextChildren(children, { ...otherProps })}</View>
+        );
+    }
+
+    const styleResolved = style ? convertStyleRNToRNS(style) as RNSStyle & RNOnlyTextStyles : void 0;
+
+    return (
+        <textView {...mapEventHandlersRNToRNS(otherProps)} style={styleResolved}>
+            {children}
+        </textView>
+    );
+};

--- a/packages/nativescript-yogalayout/react/TextInput.tsx
+++ b/packages/nativescript-yogalayout/react/TextInput.tsx
@@ -1,0 +1,75 @@
+/// <reference path="./index.ts" />
+
+import * as React from "react";
+import { View } from "./View";
+import type { RNOnlyTextStyles, RNOnlyTextProps } from "./Text";
+import { nestTextChildren } from "./Text";
+import { convertStyleRNToRNS, mapEventHandlersRNToRNS } from "./ReactNativeCompat";
+import { TextField } from "@nativescript/core";
+import { NativeScriptProps, RNSStyle, TextFieldAttributes } from "react-nativescript";
+
+/**
+ * @see https://facebook.github.io/react-native/docs/textinput.html#props
+ * @see TextInputProps["style"] in @types/react-native
+ */
+export interface RNOnlyTextInputStyles extends RNOnlyTextStyles {}
+
+/**
+ * Note: Should in future extend YogaProps (and Yoga styles), but for now we implement it with TextField.
+ * We'll need a dedicated TextInput component based on Yoga layout for the real deal.
+ * 
+ * Under-the-hood, I've implemented it as a TextField, so it's easiest just to extend TextFieldAttributes.
+ * These props are filled in primarily for API compatibility with React Native's text component.
+ * In any cases where the feature does not exist in NativeScript, we accept the prop but no-op.
+ * 
+ * There are many more RN-only props than this, but only these are used in RNTester, so we'll support just
+ * these for now.
+ */
+export interface RNTextInputProps extends Omit<NativeScriptProps<TextFieldAttributes, TextField>, "style">, RNOnlyTextProps {
+    onTextLayout?: (...args: any[]) => void,
+    suppressHighlighting?: boolean,
+    allowFontScaling?: boolean,
+    multiline?: boolean,
+    adjustsFontSizeToFit?: boolean,
+    selectable?: boolean,
+    ellipsizeMode?: "tail"|"middle"|"head"|"clip",
+    numberOfLines?: number,
+
+    style?: RNSStyle & RNOnlyTextStyles;
+}
+
+export function TextInput(props: RNTextInputProps){
+    const {
+        style,
+        onPress,
+        onTextLayout,
+
+        /* Not supported in {N}? */
+        multiline,
+        suppressHighlighting,
+        allowFontScaling,
+        adjustsFontSizeToFit,
+        selectable,
+        ellipsizeMode,
+        numberOfLines,
+
+        children,
+        ...otherProps
+    } = props;
+
+    /* Here's my very limited support for nesting children inside Text (which I don't like as a pattern anyway...) */
+    if(React.Children.count(children) > 1){
+        return (
+            // RNTester seems to default to row direction in nested texts.
+            <View flexDirection={'row'}>{nestTextChildren(children, { ...otherProps })}</View>
+        );
+    }
+
+    const styleResolved = style ? convertStyleRNToRNS(style) as RNSStyle & RNOnlyTextStyles : void 0;
+
+    return (
+        <textField {...mapEventHandlersRNToRNS(otherProps)} style={styleResolved}>
+            {children}
+        </textField>
+    );
+};

--- a/packages/nativescript-yogalayout/react/TextInput.tsx
+++ b/packages/nativescript-yogalayout/react/TextInput.tsx
@@ -68,7 +68,7 @@ export function TextInput(props: RNTextInputProps){
     const styleResolved = style ? convertStyleRNToRNS(style) as RNSStyle & RNOnlyTextStyles : void 0;
 
     return (
-        <textField {...mapEventHandlersRNToRNS(otherProps)} style={styleResolved}>
+        <textField {...mapEventHandlersRNToRNS(otherProps)}  {...(styleResolved ? { style: styleResolved } : {})}>
             {children}
         </textField>
     );

--- a/packages/nativescript-yogalayout/react/View.tsx
+++ b/packages/nativescript-yogalayout/react/View.tsx
@@ -2,8 +2,7 @@
 
 import * as React from "react";
 import type { YogaProps } from "./index";
-import { Color } from "@nativescript/core";
-import { FontWeight } from "@nativescript/core/ui/enums";
+import { convertStyleRNToRNS, mapEventHandlersRNToRNS } from "./ReactNativeCompat";
 
 export function View(props: RNViewProps = {}){
     const { style, ...otherProps } = props;
@@ -16,195 +15,24 @@ export function View(props: RNViewProps = {}){
 }
 
 /**
- * We accept these at the typings level just to enable API compatibility, but any unsupported keys or values will be treated as a no-op.
+ * @see https://facebook.github.io/react-native/docs/view.html#style
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
+ * @see ViewStyle
  */
- export interface RNOnlyStyles {
-    tintColor?: string;
-    placeholderColor?: string;
-    
-    textShadowOffset?: { width: number, height: number };
-    textShadowRadius?: number;
-    textShadowColor?: string;
-    fontVariant?: string[];
-    
-    direction?: "inherit" | "ltr" | "rtl"; // Technically ios-only, according to @types/react-native
-    textAlign?: "auto" | "initial" | "left" | "center" | "right" | "justify";
-    textDecorationLine?: "none" | "underline" | "line-through" | "underline line-through";
-    textDecorationStyle?: "solid" | "double" | "dashed" | "dotted";
-    textDecorationColor?: string;
+export interface RNOnlyViewStyles {
+    // There are certainly some, but not used in RNTester.
 }
+
+// export interface RNOnlyStyles extends RNOnlyTextStyles, RNOnlyViewStyles {
+//     // tintColor?: string; // No longer in @types/react-native.
+    
+//     // placeholderColor?: string; // I may have meant 'placeholderTextColor' in TextInputProps
+// }
 
 export interface RNViewProps extends YogaProps {
-    style?: YogaProps["style"] & RNOnlyStyles;
-}
-
-export function mapEventHandlersRNToRNS(handlers: Record<string, any>): RNViewProps {
-    return Object.keys(handlers).reduce((acc: Record<string, any>, name: string) => {
-        const handler = handlers[name];
-        const mappedName = mapEventHandlerNameRNToRNS(name);
-        if(mappedName === null){
-            delete handlers[name];
-            return acc;
-        }
-        if(mappedName === name){
-            return acc;
-        }
-        delete handlers[name];
-        handlers[mappedName] = handler;
-        return acc;
-    }, handlers);
-}
-
-export function mapEventHandlerNameRNToRNS(name: string): string | null {
-    switch(name){
-        case "onPress":
-            return "onTap";
-        case "onTextLayout":
-            // Not supported
-            return null;
-        default:
-            return name;
-    }
-}
-
-export function convertStyleRNToRNS(styles: RNViewProps["style"] | RNViewProps["style"][]): RNViewProps["style"] {
-    const flattenedStyle: RNViewProps["style"] = flattenStyle(styles);
-
-    /* Here we shallow-clone the flattened style to avoid any objects sharing the same instance of e.g. FontWeight and Color. */
-    // const style: Partial<PermissiveStyle> = { ...flattenedStyle };
-
-    return Object.keys(flattenedStyle).reduce((acc: RNViewProps["style"], name: string) => {
-        const mapping = mapStyleRNToRNS(name, flattenedStyle[name]);
-        delete flattenedStyle[name];
-        if(mapping === null) return acc; // Explicitly not supported.
-
-        Object.keys(mapping).forEach((key: string) => {
-            flattenedStyle[key] = mapping[key];
-        });
-        return acc;
-    }, flattenedStyle);
-}
-
-export function flattenStyle(styles: RNViewProps["style"] | RNViewProps["style"][]): RNViewProps["style"] {
-    if(!Array.isArray(styles)) return styles;
-    return Object.assign({}, ...styles);
-}
-
-export function mapStyleRNToRNS(name: string, value: string): Record<string, any>|null {
-    switch(name){
-        case "textShadowColor":
-        case "textShadowRadius":
-        case "textShadowOffset":
-        case "fontVariant":
-            return null;
-        case "fontWeight":
-            let fontWeight;
-            switch(value){
-                case "100":
-                case "thin":
-                    fontWeight = FontWeight.thin; // 100
-                case "200":
-                case "extraLight":
-                    fontWeight = FontWeight.extraLight; // 200
-                case "300":
-                case "light":
-                    fontWeight = FontWeight.light; // 300
-                case "400":
-                case "normal":
-                    fontWeight = FontWeight.normal; // 400
-                case "500":
-                case "medium":
-                    fontWeight = FontWeight.medium; // 500
-                case "600":
-                case "semiBold":
-                    fontWeight = FontWeight.semiBold; // 600
-                case "700":
-                case "bold":
-                    fontWeight = FontWeight.bold; // 700
-                case "800":
-                case "extraBold":
-                    fontWeight = FontWeight.extraBold; // 800
-                case "900":
-                case "black":
-                    fontWeight = FontWeight.black; // 900
-                default:
-                    fontWeight = FontWeight.normal; // I don't have the motivation to support in-between values.
-            }
-            return { [name]: fontWeight };
-        case "textAlign": {
-            if(value === "justify" || value === "auto"){
-                // Not supported.
-                return null;
-            }
-            return { "textAlignment": value };
-        }
-        case "textDecorationLine":
-            return { "textDecoration": value };
-        // NativeScript text decorations can't be coloured nor styled, as far as I understand.
-        case "textDecorationStyle":
-        case "textDecorationColor":
-            return null;
-        case "tintColor": // Supported only on Image component
-        case "placeholderColor": // Not supported at all
-            return null;
-        case "color":
-        case "backgroundColor":
-        case "borderTopColor":
-        case "borderRightColor":
-        case "borderBottomColor":
-        case "borderLeftColor":
-        case "tabTextColor":
-        case "tabBackgroundColor":
-        case "selectedTabTextColor":
-        case "androidSelectedTabHighlightColor":
-        case "separatorColor":
-        case "selectedBackgroundColor":
-        case "androidStatusBarBackground": {
-            /**
-             * @see https://facebook.github.io/react-native/docs/colors
-             */
-            if(typeof value === "string" || (value as any) instanceof Color){
-                return { [name]: value };
-            }
-            return null;
-        }
-        case "position":
-        case "direction": // Beware: We don't have a cross-platform API for this yet; it relies upon Obj-C and iOS enums for now. React Native expects "inherit" | "ltr" | "rtl".
-        case "width":
-        case "height":
-        case "marginLeft":
-        case "marginTop":
-        case "marginRight":
-        case "marginBottom":
-        case "borderWidth":
-        case "borderTopWidth":
-        case "borderRightWidth":
-        case "borderBottomWidth":
-        case "borderLeftWidth":
-        case "borderRadius":
-        case "borderTopLeftRadius":
-        case "borderTopRightRadius":
-        case "borderBottomRightRadius":
-        case "borderBottomLeftRadius":
-        case "minWidth":
-        case "minHeight":
-        case "paddingLeft":
-        case "paddingTop":
-        case "paddingRight":
-        case "paddingBottom":
-        case "paddingVertical":
-        case "paddingHorizontal":
-        case "top":
-        case "left":
-        case "right":
-        case "bottom":
-        case "padding":
-        case "margin":
-        case "borderColor":
-        case "borderWidth":
-            return { [name]: value };
-        default:
-            /* We'll see how this goes... */
-            return { [name]: value };
-    }
+    /**
+     * We accept these styles at the typings level just to enable API compatibility, but any
+     * unsupported keys or values will be treated as a no-op.
+     */
+    style?: YogaProps["style"] & RNOnlyViewStyles;
 }

--- a/packages/nativescript-yogalayout/react/View.tsx
+++ b/packages/nativescript-yogalayout/react/View.tsx
@@ -1,0 +1,247 @@
+/// <reference path="./index.ts" />
+
+import * as React from "react";
+import { YogaAttributes } from "./index";
+import type {View as YogaLayout} from '../';
+import { Color, Length, PercentLength } from "@nativescript/core";
+import { NativeScriptProps, RNSStyle } from "react-nativescript";
+import { FontWeight } from "@nativescript/core/ui/enums";
+
+export function View(props: RNViewProps = {}){
+    const { style = {}, ...rest } = props;
+    return (
+        //@ts-ignore Everything will be fine
+        <yoga flexDirection={"column"} {...mapEventHandlersRNToRNS(rest)} {...convertStyleRNToRNS(style)} />
+    );
+}
+
+export function mapEventHandlersRNToRNS(handlers: Record<string, (...args: any[]) => void>): Record<string, (...args: any[]) => void> {
+    return Object.keys(handlers).reduce((acc: Record<string, (...args: any[]) => void>, name: string) => {
+        const handler = handlers[name];
+        const mappedName = mapEventHandlerNameRNToRNS(name, handler);
+        if(mappedName === null){
+            delete handlers[name];
+            return acc;
+        }
+        if(mappedName === name){
+            return acc;
+        }
+        delete handlers[name];
+        handlers[mappedName] = handler;
+        return acc;
+    }, handlers);
+}
+
+export function mapEventHandlerNameRNToRNS(name: string, value: (...args: any[]) => void): string | null {
+    switch(name){
+        case "onPress":
+            return "onTap";
+        case "onTextLayout":
+            // Not supported
+            return null;
+        default:
+            return name;
+    }
+}
+
+export function convertStyleRNToRNS(styles: RNViewProps["style"] | RNViewProps["style"][]): RNViewProps["style"] {
+    const flattenedStyle: RNViewProps["style"] = flattenStyle(styles);
+
+    /* Here we shallow-clone the flattened style to avoid any objects sharing the same instance of e.g. FontWeight and Color. */
+    // const style: Partial<PermissiveStyle> = { ...flattenedStyle };
+
+    return Object.keys(flattenedStyle).reduce((acc: RNViewProps["style"], name: string) => {
+        const mapping = mapStyleRNToRNS(name, flattenedStyle[name]);
+        delete flattenedStyle[name];
+        if(mapping === null) return acc; // Explicitly not supported.
+
+        Object.keys(mapping).forEach((key: string) => {
+            flattenedStyle[key] = mapping[key];
+        });
+        return acc;
+    }, flattenedStyle);
+}
+
+export function flattenStyle(styles: RNViewProps["style"] | RNViewProps["style"][]): RNViewProps["style"] {
+    if(!Array.isArray(styles)) return styles;
+    return Object.assign({}, ...styles);
+}
+
+export function mapStyleRNToRNS(name: string, value: string): Record<string, any>|null {
+    switch(name){
+        case "textShadowColor":
+        case "textShadowRadius":
+        case "textShadowOffset":
+        case "fontVariant":
+            return null;
+        case "position":
+            return { [name]: value };
+        // Not sure what this would map to in NS.
+        /**
+         * @see https://facebook.github.io/react-native/docs/layout-props#direction
+         */
+        case "direction":
+            return null;
+        case "fontWeight":
+            let fontWeight;
+            switch(value){
+                case "100":
+                case "thin":
+                    fontWeight = FontWeight.thin; // 100
+                case "200":
+                case "extraLight":
+                    fontWeight = FontWeight.extraLight; // 200
+                case "300":
+                case "light":
+                    fontWeight = FontWeight.light; // 300
+                case "400":
+                case "normal":
+                    fontWeight = FontWeight.normal; // 400
+                case "500":
+                case "medium":
+                    fontWeight = FontWeight.medium; // 500
+                case "600":
+                case "semiBold":
+                    fontWeight = FontWeight.semiBold; // 600
+                case "700":
+                case "bold":
+                    fontWeight = FontWeight.bold; // 700
+                case "800":
+                case "extraBold":
+                    fontWeight = FontWeight.extraBold; // 800
+                case "900":
+                case "black":
+                    fontWeight = FontWeight.black; // 900
+                default:
+                    fontWeight = FontWeight.normal; // I don't have the motivation to support in-between values.
+            }
+            return { [name]: fontWeight };
+        case "textAlign":
+            return (value === "justify" || value === "auto") ? null : { "textAlignment": value }; // "auto" and "justify" not supported.
+        case "textDecorationLine":
+            return { "textDecoration": value };
+        // NativeScript text decorations can't be coloured nor styled, as far as I understand.
+        case "textDecorationStyle":
+        case "textDecorationColor":
+            return null;
+        case "color":
+        case "tintColor":
+        case "placeholderColor":
+        case "backgroundColor":
+        case "borderTopColor":
+        case "borderRightColor":
+        case "borderBottomColor":
+        case "borderLeftColor":
+        case "tabTextColor":
+        case "tabBackgroundColor":
+        case "selectedTabTextColor":
+        case "androidSelectedTabHighlightColor":
+        case "separatorColor":
+        case "selectedBackgroundColor":
+        case "androidStatusBarBackground": {
+            /**
+             * @see https://facebook.github.io/react-native/docs/colors
+             */
+            if(typeof value === "string" || (value as any) instanceof Color){
+                return { [name]: value };
+            }
+            return null;
+        }
+        case "width":
+        case "height":
+        case "marginLeft":
+        case "marginTop":
+        case "marginRight":
+        case "marginBottom":
+            return { [name]: value };
+        case "marginVertical":
+        case "marginHorizontal":
+            return name === "marginVertical" ? 
+            {
+                "marginTop": value,
+                "marginBottom": value,
+            } : 
+            {
+                "marginLeft": value,
+                "marginRight": value,
+            };
+        case "borderWidth":
+        case "borderTopWidth":
+        case "borderRightWidth":
+        case "borderBottomWidth":
+        case "borderLeftWidth":
+        case "borderRadius":
+        case "borderTopLeftRadius":
+        case "borderTopRightRadius":
+        case "borderBottomRightRadius":
+        case "borderBottomLeftRadius":
+        case "minWidth":
+        case "minHeight":
+        case "paddingLeft":
+        case "paddingTop":
+        case "paddingRight":
+        case "paddingBottom":
+
+        case "top":
+        case "left":
+        case "right":
+        case "bottom":
+            return { [name]: value };
+        /* strings allowed */
+        case "padding":
+        case "margin":
+        case "borderColor":
+        case "borderWidth":
+            return { [name]: value };
+        default:
+            /* We'll see how this goes... */
+            return { [name]: value };
+    }
+}
+
+/**
+ * see https://facebook.github.io/react-native/docs/height-and-width.html
+ */
+export function mapLengthRNToRNS(name: string, length: number|string, expectsPercent: boolean|null): Length|PercentLength {
+    if(typeof length === "string"){
+        if(length.slice(-1) === "%"){
+            if(!expectsPercent){
+                throw new Error(`Percent length not allowed for property '${name}'`);
+            }
+            return { value: parseFloat(length), unit: "%" };
+        } else {
+            if(expectsPercent){
+                throw new Error(`Percent length expected for property '${name}'`);
+            }
+            return { value: parseFloat(length), unit: "dip" };
+        }
+    } else {
+        return { value: length, unit: "dip" };
+    }
+    // return typeof length === "string" ? 
+    //     { value: parseFloat(length), unit: length.slice(-1) === "%" ? "%" : "dip" } :
+    //     { value: length, unit: "dip" };
+}
+
+export interface RNOnlyStyles {
+    tintColor?: string;
+    placeholderColor?: string;
+    
+    textShadowOffset?: { width: number, height: number };
+    textShadowRadius?: number;
+    textShadowColor?: string;
+    fontVariant?: string[];
+    
+    position?: "absolute"|"relative";
+    direction?: "inherit" | "ltr" | "rtl"; // Technically ios-only, according to @types/react-native
+    marginVertical?: number;
+    marginHorizontal?: number;
+    textAlign?: "auto"|"initial" | "left" | "center" | "right" | "justify";
+    textDecorationLine?: "none" | "underline" | "line-through" | "underline line-through";
+    textDecorationStyle?: "solid" | "double" | "dashed" | "dotted";
+    textDecorationColor?: string;
+}
+
+export interface RNViewProps extends NativeScriptProps<YogaAttributes, YogaLayout> {
+    style?: RNSStyle & RNOnlyStyles;
+}

--- a/packages/nativescript-yogalayout/react/View.tsx
+++ b/packages/nativescript-yogalayout/react/View.tsx
@@ -10,7 +10,7 @@ export function View(props: RNViewProps = {}){
     const styleResolved = style ? convertStyleRNToRNS(style) : void 0;
 
     return (
-        <yoga flexDirection="column" {...mapEventHandlersRNToRNS(otherProps)} style={styleResolved} />
+        <yoga flexDirection="column" {...mapEventHandlersRNToRNS(otherProps)}  {...(styleResolved ? { style: styleResolved } : {})} />
     );
 }
 

--- a/packages/nativescript-yogalayout/react/View.tsx
+++ b/packages/nativescript-yogalayout/react/View.tsx
@@ -10,7 +10,7 @@ export function View(props: RNViewProps = {}){
     const styleResolved = style ? convertStyleRNToRNS(style) : void 0;
 
     return (
-        <yoga flexDirection="column" {...mapEventHandlersRNToRNS(otherProps)}  {...(styleResolved ? { style: styleResolved } : {})} />
+        <yoga flexDirection="column" flexShrink={0} alignContent="flex-start" {...mapEventHandlersRNToRNS(otherProps)}  {...(styleResolved ? { style: styleResolved } : {})} />
     );
 }
 

--- a/packages/nativescript-yogalayout/react/index.ts
+++ b/packages/nativescript-yogalayout/react/index.ts
@@ -11,8 +11,6 @@ export function registerYogaLayout(): void {
   registerElement('yoga', () => require('../').View);
 }
 
-export { View, RNViewProps } from "./View";
-
 export interface YogaDistinctAttributes {
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
@@ -180,3 +178,8 @@ declare module "react-nativescript" {
     direction?: YogaDistinctAttributes["direction"];
   }
 }
+
+export { View, RNViewProps as ViewProps } from "./View";
+export { Text, RNTextProps as TextProps } from "./Text";
+export { TextInput, RNTextInputProps as TextInputProps } from "./TextInput";
+export { Button, RNButtonProps as ButtonProps } from "./Button";

--- a/packages/nativescript-yogalayout/react/index.ts
+++ b/packages/nativescript-yogalayout/react/index.ts
@@ -13,7 +13,7 @@ export function registerYogaLayout(): void {
 
 export { View, RNViewProps } from "./View";
 
-export type YogaAttributes = ViewAttributes & {
+interface YogaDistinctAttributes {
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
@@ -34,7 +34,15 @@ export type YogaAttributes = ViewAttributes & {
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
   padding?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
-
+  /**
+   * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
+   */
+  paddingVertical?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
+  /**
+   * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
+   */
+  paddingHorizontal?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
+  
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
@@ -55,7 +63,15 @@ export type YogaAttributes = ViewAttributes & {
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
   margin?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
-
+  /**
+   * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
+   */
+  marginHorizontal?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
+  /**
+   * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
+   */
+  marginVertical?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
+  
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
@@ -80,7 +96,7 @@ export type YogaAttributes = ViewAttributes & {
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
   end?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
-
+  
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
@@ -89,30 +105,64 @@ export type YogaAttributes = ViewAttributes & {
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
   maxWidth?: string | number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
-
+  
   alignItems?: "stretch" | "center" | "flex-end" | "flex-start" | "baseline";
   overflow?: "visible" | "hidden" | "scroll";
   position?: "relative" | "absolute";
   alignSelf?: "stretch" | "center" | "flex-end" | "flex-start" | "baseline" | "auto";
   flexGrow?: number;
   flexShrink?: number;
-
+  
   /**
    * Number values are interpreted as display-independent pixels.
    */
   flexBasis?: number | LengthDipUnit | LengthPxUnit | LengthPercentUnit;
   flex?: number;
   flexDirection?: "row" | "column" | "column-reverse" | "row-reverse";
+  /**
+   * TODO: Change the implementation to accept a cross-platform "rtl" | "ltr" | "inherit" enum.
+   * @platform iOS     YGDirection.RTL | YGDirection.LTR | YGDirection.Inherit
+   * @platform android com.facebook.yoga.YogaDirection.RTL | com.facebook.yoga.YogaDirection.LTR | com.facebook.yoga.YogaDirection.INHERIT
+   */
+  direction?: any;
   alignContent?: "stretch" | "center" | "flex-end" | "flex-start" | "baseline";
-
+  
   flexWrap?: "no-wrap" | "wrap" | "wrap-reverse";
   justifyContent?: "flex-start" | "flex-end" | "center" | "space-around" | "space-between" | "space-evenly";
-};
+}
+
+export type YogaAttributes = ViewAttributes & YogaDistinctAttributes;
 
 declare global {
   module JSX {
     interface IntrinsicElements {
       yoga: NativeScriptProps<YogaAttributes, YogaLayout>;
     }
+  }
+}
+
+declare module "react-nativescript" {
+  /**
+   * @see the augmentation of import("@nativescript/core").Style made by the plugin in ../common.ts.
+   */
+  interface RNSStyle {
+    left?: YogaDistinctAttributes["left"];
+    top?: YogaDistinctAttributes["top"];
+    right?: YogaDistinctAttributes["right"];
+    bottom?: YogaDistinctAttributes["bottom"];
+    start?: YogaDistinctAttributes["start"];
+    end?: YogaDistinctAttributes["end"];
+    marginVertical?: YogaDistinctAttributes["marginVertical"];
+    marginHorizontal?: YogaDistinctAttributes["marginHorizontal"];
+    paddingHorizontal?: YogaDistinctAttributes["paddingHorizontal"];
+    paddingVertical?: YogaDistinctAttributes["paddingVertical"];
+    justifyContent?: YogaDistinctAttributes["justifyContent"];
+    maxWidth?: YogaDistinctAttributes["maxWidth"];
+    maxHeight?: YogaDistinctAttributes["maxHeight"];
+    flex?: YogaDistinctAttributes["flex"];
+    overflow?: YogaDistinctAttributes["overflow"];
+    position?: YogaDistinctAttributes["position"];
+    flexBasis?: YogaDistinctAttributes["flexBasis"];
+    direction?: YogaDistinctAttributes["direction"];
   }
 }

--- a/packages/nativescript-yogalayout/react/index.ts
+++ b/packages/nativescript-yogalayout/react/index.ts
@@ -11,6 +11,8 @@ export function registerYogaLayout(): void {
   registerElement('yoga', () => require('../').View);
 }
 
+export { View, RNViewProps } from "./View";
+
 export type YogaAttributes = ViewAttributes & {
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".

--- a/packages/nativescript-yogalayout/react/index.ts
+++ b/packages/nativescript-yogalayout/react/index.ts
@@ -1,4 +1,4 @@
-import {registerElement} from 'react-nativescript';
+import {registerElement, RNSStyle} from 'react-nativescript';
 import type {View as YogaLayout} from '../';
 import {ViewAttributes, NativeScriptProps} from 'react-nativescript';
 import {
@@ -13,7 +13,7 @@ export function registerYogaLayout(): void {
 
 export { View, RNViewProps } from "./View";
 
-interface YogaDistinctAttributes {
+export interface YogaDistinctAttributes {
   /**
    * Number values are interpreted as display-independent pixels. Will no-op if set to "auto".
    */
@@ -133,10 +133,24 @@ interface YogaDistinctAttributes {
 
 export type YogaAttributes = ViewAttributes & YogaDistinctAttributes;
 
+/**
+ * NativeScript Core imposes its own values for various styles, across FlexboxLayout and other components.
+ * In the case of a name clash, we'll take the YogaLayout ones as definitive.
+ * This allows for stricter typings; for RNSStyle, we accept arbitrary strings (as it's easier than fixing the
+ * Core typings). But for YogaLayout-specific properties, we can tighten things up and enforce enumerated strings.
+ */
+type OptionalStyleAllowingStringWithFlexExceptions = Omit<RNSStyle, keyof YogaDistinctAttributes> & {
+  [P in keyof YogaDistinctAttributes]?: YogaDistinctAttributes[P];
+};
+
+export interface YogaProps extends Omit<NativeScriptProps<YogaAttributes, YogaLayout>, "style"> {
+  style?: OptionalStyleAllowingStringWithFlexExceptions;
+}
+
 declare global {
   module JSX {
     interface IntrinsicElements {
-      yoga: NativeScriptProps<YogaAttributes, YogaLayout>;
+      yoga: YogaProps;
     }
   }
 }

--- a/packages/nativescript-yogalayout/tsconfig.json
+++ b/packages/nativescript-yogalayout/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
+		"jsx": "react",
 		"outDir": "../../dist/out-tsc",
 		"rootDir": "."
 	},


### PR DESCRIPTION
Based on an older version (circa June 2019) of this UI showcase: https://github.com/facebook/react-native/tree/dc80b2dcb52fadec6a573a9dd1824393f8c29fdc/packages/rn-tester/js/examples

## Features

This introduces provisional View, Text, TextInput, and Button components which have some API compatibility with the corresponding components in React Native. Just enough to pass most of the RNTester tests. Although I recommend people not to use these components in production, they serve to port a very handy set of RNTester test cases for us to check how well YogaLayout behaves.

## Issues

This highlighted some issues:

### Lack of "auto" height/width

I can only fit a screen's worth of test cases because the YogaLayout component doesn't seem to implement "auto" height. Thus it won't size to its contents and instead must take a fraction of the available container space. The worst thing about this is that once the screen runs out of space to fit all examples, NativeScript is unable to solve the layout and stalls indefinitely.

Only once "auto" height is supported can we have a scrolling list of examples (which will let us see all test cases).

### margin/padding vertical/horizontal convenience styles

I had to comment out all usages of `marginVertical`, `marginHorizontal`, `paddingVertical`, `paddingHorizontal` (see the FIXME notes on `apps/demo-react/src/RNTesterExamples/ExampleList.tsx` because they give the error:

> Cannot read property 'yoga' of undefined

... Which indicates that the `nativeView` property of an element or child element lacked the `yoga` property.
