### PR TITLE
fix: AWS S3 uploads for iOS

### DIFF
--- a/packages/nativescript-aws-sdk-s3/common.ts
+++ b/packages/nativescript-aws-sdk-s3/common.ts
@@ -97,7 +97,7 @@ export enum S3Regions {
   AP_NORTHEAST_2 = 'ap-northeast-2',
   AP_NORTHEAST_3 = 'ap-northeast-3',
   AP_SOUTHEAST_1 = 'ap-southeast-1',
-  AP_SOUTHEAST_2 = 'ap-southeast-1',
+  AP_SOUTHEAST_2 = 'ap-southeast-2',
   CA_CENTRAL_1 = 'ca-central-1',
   CN_NORTH_1 = 'cn-north-1',
   CN_NORTHWEST_1 = 'cn-northwest-1',

--- a/packages/nativescript-aws-sdk-s3/index.ios.ts
+++ b/packages/nativescript-aws-sdk-s3/index.ios.ts
@@ -58,7 +58,7 @@ export class S3 extends S3Base {
       default:
         throw new Error('Invalid S3AuthType');
     }
-    const manager = AWSServiceManager.defaultServiceManager;
+    const manager = AWSServiceManager.defaultServiceManager();
     config = AWSServiceConfiguration.alloc().initWithRegionEndpointCredentialsProvider(S3.getRegion(options.region), endPoint, credentialsProvider);
     config.maxRetryCount = 5;
     config.timeoutIntervalForRequest = 30;
@@ -131,7 +131,7 @@ export class S3 extends S3Base {
   }
 
   public createUpload(options: S3UploadOptions): number {
-    const transferUtility = AWSS3TransferUtility.defaultS3TransferUtility;
+    const transferUtility = AWSS3TransferUtility.defaultS3TransferUtility();
     const appRoot = knownFolders.currentApp().path;
     let file;
     if (options.file && options.file.startsWith('~/')) {
@@ -232,7 +232,7 @@ export class S3 extends S3Base {
       }
       return null;
     });
-    const manager = AWSServiceManager.defaultServiceManager;
+    const manager = AWSServiceManager.defaultServiceManager();
     S3.OperationsData.set(id, {
       status: StatusCode.PENDING,
       path: file.path,
@@ -246,7 +246,7 @@ export class S3 extends S3Base {
   }
 
   public createDownload(options: S3DownloadOptions): number {
-    const transferUtility = AWSS3TransferUtility.defaultS3TransferUtility
+    const transferUtility = AWSS3TransferUtility.defaultS3TransferUtility()
     const appRoot = knownFolders.currentApp().path;
 
     let file;


### PR DESCRIPTION
Fix typeerror in iOS by making `defaultS3TransferUtility` and `defaultServiceManager` function calls.

Also fix typo for `AP_SOUTHEAST_2`.