### PR TITLE
fix: do not use require in angular packages

### DIFF
--- a/packages/nativescript-accordion/angular/index.ts
+++ b/packages/nativescript-accordion/angular/index.ts
@@ -40,7 +40,7 @@ import {
 import {getSingleViewRecursive, registerElement} from '@nativescript/angular';
 import {Accordion} from '@triniwiz/nativescript-accordion';
 
-registerElement('Accordion', () => require('@triniwiz/nativescript-accordion').Accordion);
+registerElement('Accordion', () => Accordion);
 
 const NG_VIEW = '_ngViewRef';
 

--- a/packages/nativescript-image-cache-it/angular/index.ts
+++ b/packages/nativescript-image-cache-it/angular/index.ts
@@ -1,15 +1,14 @@
-import {NgModule} from '@angular/core';
-import {registerElement} from '@nativescript/angular';
+import { NgModule } from '@angular/core';
+import { registerElement } from '@nativescript/angular';
 
-import {ImageCacheItDirective} from './image-cache-it.directive';
+import { ImageCacheItDirective } from './image-cache-it.directive';
 export * from './image-cache-it.directive';
+import { ImageCacheIt } from '@triniwiz/nativescript-image-cache-it';
 
 @NgModule({
-  declarations: [ImageCacheItDirective],
-  exports: [ImageCacheItDirective],
+	declarations: [ImageCacheItDirective],
+	exports: [ImageCacheItDirective],
 })
-// @ts-ignore
-export class ImageCacheItModule {
-}
+export class ImageCacheItModule {}
 
-registerElement('ImageCacheIt', () => require('@triniwiz/nativescript-image-cache-it').ImageCacheIt);
+registerElement('ImageCacheIt', () => ImageCacheIt);

--- a/packages/nativescript-stripe/angular/index.ts
+++ b/packages/nativescript-stripe/angular/index.ts
@@ -2,13 +2,13 @@ import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { registerElement } from "@nativescript/angular";
 import { DIRECTIVES } from "./nativescript-stripe.directives";
 export * from './nativescript-stripe.directives';
+import { CreditCardView } from "@triniwiz/nativescript-stripe"
 
-registerElement("CreditCardView", () => require("@triniwiz/nativescript-stripe").CreditCardView);
+registerElement("CreditCardView", () => CreditCardView);
 
 @NgModule({
   declarations: [DIRECTIVES],
   exports: [DIRECTIVES],
   schemas: [NO_ERRORS_SCHEMA]
 })
-// @ts-ignore
 export class CreditCardViewModule { }

--- a/packages/nativescript-stripe/angular/nativescript-stripe.directives.ts
+++ b/packages/nativescript-stripe/angular/nativescript-stripe.directives.ts
@@ -4,7 +4,6 @@ import { Directive } from "@angular/core";
 @Directive({
     selector: "CreditCardView"
 })
-// @ts-ignore
 export class CreditCardViewDirective { }
 
 export const DIRECTIVES = CreditCardViewDirective;

--- a/packages/nativescript-yogalayout/angular/index.ts
+++ b/packages/nativescript-yogalayout/angular/index.ts
@@ -4,12 +4,13 @@ import {registerElement} from '@nativescript/angular';
 import {YogaLayoutItDirective} from './yogalayout.directive';
 export * from './yogalayout.directive';
 
+import { View } from '@triniwiz/nativescript-yogalayout';
+
 @NgModule({
   declarations: [YogaLayoutItDirective],
   exports: [YogaLayoutItDirective],
 })
-// @ts-ignore
 export class YogaLayoutModule {
 }
 
-registerElement('View', () => require('@triniwiz/nativescript-yogalayout').View);
+registerElement('View', () => View);

--- a/packages/nativescript-youtubeplayer/angular/index.ts
+++ b/packages/nativescript-youtubeplayer/angular/index.ts
@@ -9,5 +9,4 @@ registerElement('YoutubePlayer', () => YoutubePlayer);
 	exports: [DIRECTIVES],
 	schemas: [NO_ERRORS_SCHEMA],
 })
-//@ts-ignore
 export class YoutubePlayerModule {}

--- a/packages/nativescript-youtubeplayer/angular/nativescript-youtubeplayer.directives.ts
+++ b/packages/nativescript-youtubeplayer/angular/nativescript-youtubeplayer.directives.ts
@@ -3,7 +3,6 @@ import { Directive } from '@angular/core';
 @Directive({
 	selector: 'YoutubePlayer',
 })
-// @ts-ignore
 export class YoutubePlayerDirective {}
 
 export const DIRECTIVES = [YoutubePlayerDirective];


### PR DESCRIPTION
require on angular packages breaks on angular 14+ (they're not processed by webpack)