### PR TITLE
chore: couchbase libs update to 3.0.0

### DIFF
--- a/packages/nativescript-couchbase/platforms/android/include.gradle
+++ b/packages/nativescript-couchbase/platforms/android/include.gradle
@@ -16,5 +16,5 @@ repositories {
   }
 }
 dependencies {
-  implementation 'com.couchbase.lite:couchbase-lite-android:2.8.6'
+  implementation 'com.couchbase.lite:couchbase-lite-android:3.0.0'
 }

--- a/packages/nativescript-couchbase/platforms/ios/Podfile
+++ b/packages/nativescript-couchbase/platforms/ios/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '10.0'
 use_frameworks!
-pod 'CouchbaseLite', '~> 2.8.4'
+pod 'CouchbaseLite', '~> 3.0.0'

--- a/packages/nativescript-couchbase/typings/android-declarations.d.ts
+++ b/packages/nativescript-couchbase/typings/android-declarations.d.ts
@@ -1,0 +1,4 @@
+declare module androidNative {	export class Array<T> {	constructor(); length: number; [index: number]: T; } }
+
+import globalAndroid = android;
+

--- a/packages/nativescript-couchbase/typings/android.d.ts
+++ b/packages/nativescript-couchbase/typings/android.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="android-declarations.d.ts"/>
+
 declare module com {
 	export module couchbase {
 		export module lite {
@@ -9,6 +11,8 @@ declare module com {
 				public setDomains(param0: java.util.EnumSet<com.couchbase.lite.LogDomain>): void;
 				public doLog(param0: com.couchbase.lite.LogLevel, param1: com.couchbase.lite.LogDomain, param2: string): void;
 				public getLevel(): com.couchbase.lite.LogLevel;
+				public setDomains(param0: androidNative.Array<com.couchbase.lite.LogDomain>): void;
+				public constructor();
 			}
 		}
 	}
@@ -17,27 +21,28 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export abstract class AbstractDatabase {
+			export abstract class AbstractDatabase extends com.couchbase.lite.BaseDatabase {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractDatabase>;
 				public static log: com.couchbase.lite.Log;
-				public c4db: com.couchbase.lite.internal.core.C4Database;
+				public config: com.couchbase.lite.internal.ImmutableDatabaseConfiguration;
+				public getBlob(param0: java.util.Map<string,any>): com.couchbase.lite.Blob;
 				public save(param0: com.couchbase.lite.MutableDocument, param1: com.couchbase.lite.ConflictHandler): boolean;
-				public mustBeOpen(): void;
 				public constructor(param0: string, param1: com.couchbase.lite.DatabaseConfiguration);
 				public addDocumentChangeListener(param0: string, param1: com.couchbase.lite.DocumentChangeListener): com.couchbase.lite.ListenerToken;
 				public finalize(): void;
 				public save(param0: com.couchbase.lite.MutableDocument, param1: com.couchbase.lite.ConcurrencyControl): boolean;
+				public inBatch(param0: com.couchbase.lite.UnitOfWork<any>): void;
 				public static exists(param0: string, param1: java.io.File): boolean;
-				public compact(): void;
-				public static copy(param0: java.io.File, param1: string, param2: com.couchbase.lite.DatabaseConfiguration, param3: number, param4: native.Array<number>): void;
-				public constructor(param0: com.couchbase.lite.internal.core.C4Database);
+				public constructor(param0: string);
+				public performMaintenance(param0: com.couchbase.lite.MaintenanceType): boolean;
+				public constructor();
+				public constructor(param0: string, param1: com.couchbase.lite.internal.ImmutableDatabaseConfiguration);
 				public createIndex(param0: string, param1: com.couchbase.lite.Index): void;
-				/** @deprecated */
-				public static setLogLevel(param0: com.couchbase.lite.LogDomain, param1: com.couchbase.lite.LogLevel): void;
-				public inBatch(param0: java.lang.Runnable): void;
 				public delete(): void;
+				public static copy(param0: java.io.File, param1: string, param2: string, param3: number, param4: androidNative.Array<number>): void;
 				public save(param0: com.couchbase.lite.MutableDocument): void;
 				public delete(param0: com.couchbase.lite.Document): void;
+				public createQuery(param0: string): com.couchbase.lite.Query;
 				public purge(param0: string): void;
 				public close(): void;
 				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
@@ -45,6 +50,7 @@ declare module com {
 				public getCount(): number;
 				public getDocument(param0: string): com.couchbase.lite.Document;
 				public getPath(): string;
+				public saveBlob(param0: com.couchbase.lite.Blob): void;
 				public addChangeListener(param0: com.couchbase.lite.DatabaseChangeListener): com.couchbase.lite.ListenerToken;
 				public toString(): string;
 				public addDocumentChangeListener(param0: string, param1: java.util.concurrent.Executor, param2: com.couchbase.lite.DocumentChangeListener): com.couchbase.lite.ListenerToken;
@@ -53,10 +59,21 @@ declare module com {
 				public getDocumentExpiration(param0: string): java.util.Date;
 				public getIndexes(): java.util.List<string>;
 				public setDocumentExpiration(param0: string, param1: java.util.Date): void;
+				public createIndex(param0: string, param1: com.couchbase.lite.IndexConfiguration): void;
 				public delete(param0: com.couchbase.lite.Document, param1: com.couchbase.lite.ConcurrencyControl): boolean;
 				public static delete(param0: string, param1: java.io.File): void;
 				public deleteIndex(param0: string): void;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.DatabaseChangeListener): com.couchbase.lite.ListenerToken;
+			}
+			export module AbstractDatabase {
+				export class ActiveProcess<T>  extends java.lang.Object {
+					public static class: java.lang.Class<com.couchbase.lite.AbstractDatabase.ActiveProcess<any>>;
+					public equals(param0: any): boolean;
+					public isActive(): boolean;
+					public toString(): string;
+					public stop(): void;
+					public hashCode(): number;
+				}
 			}
 		}
 	}
@@ -67,11 +84,11 @@ declare module com {
 		export module lite {
 			export abstract class AbstractDatabaseConfiguration {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractDatabaseConfiguration>;
-				public setDirectory(param0: string): com.couchbase.lite.AbstractDatabaseConfiguration;
-				public setReadonly(param0: boolean): void;
+				public setDirectory(param0: string): com.couchbase.lite.DatabaseConfiguration;
+				public constructor(param0: com.couchbase.lite.internal.BaseImmutableDatabaseConfiguration);
 				public getDatabaseConfiguration(): com.couchbase.lite.DatabaseConfiguration;
 				public constructor(param0: com.couchbase.lite.AbstractDatabaseConfiguration);
-				public isReadonly(): boolean;
+				public constructor(param0: string);
 				public constructor();
 				public getDirectory(): string;
 			}
@@ -132,8 +149,29 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export abstract class AbstractIndex extends com.couchbase.lite.Index {
+			export abstract class AbstractIndex {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractIndex>;
+				public constructor(param0: com.couchbase.lite.AbstractIndex.IndexType, param1: com.couchbase.lite.AbstractIndex.QueryLanguage);
+				public toString(): string;
+			}
+			export module AbstractIndex {
+				export class IndexType {
+					public static class: java.lang.Class<com.couchbase.lite.AbstractIndex.IndexType>;
+					public static VALUE: com.couchbase.lite.AbstractIndex.IndexType;
+					public static FULL_TEXT: com.couchbase.lite.AbstractIndex.IndexType;
+					public static PREDICTIVE: com.couchbase.lite.AbstractIndex.IndexType;
+					public getValue(): number;
+					public static valueOf(param0: string): com.couchbase.lite.AbstractIndex.IndexType;
+					public static values(): androidNative.Array<com.couchbase.lite.AbstractIndex.IndexType>;
+				}
+				export class QueryLanguage {
+					public static class: java.lang.Class<com.couchbase.lite.AbstractIndex.QueryLanguage>;
+					public static JSON: com.couchbase.lite.AbstractIndex.QueryLanguage;
+					public static N1QL: com.couchbase.lite.AbstractIndex.QueryLanguage;
+					public getValue(): number;
+					public static valueOf(param0: string): com.couchbase.lite.AbstractIndex.QueryLanguage;
+					public static values(): androidNative.Array<com.couchbase.lite.AbstractIndex.QueryLanguage>;
+				}
 			}
 		}
 	}
@@ -142,20 +180,10 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export abstract class AbstractIndexBuilder {
+			export class AbstractIndexBuilder {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractIndexBuilder>;
-				public static fullTextIndex(param0: native.Array<com.couchbase.lite.FullTextIndexItem>): com.couchbase.lite.FullTextIndex;
-				public static valueIndex(param0: native.Array<com.couchbase.lite.ValueIndexItem>): com.couchbase.lite.ValueIndex;
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export abstract class AbstractNetworkReachabilityManager {
-				public static class: java.lang.Class<com.couchbase.lite.AbstractNetworkReachabilityManager>;
+				public static fullTextIndex(param0: androidNative.Array<com.couchbase.lite.FullTextIndexItem>): com.couchbase.lite.FullTextIndex;
+				public static valueIndex(param0: androidNative.Array<com.couchbase.lite.ValueIndexItem>): com.couchbase.lite.ValueIndex;
 			}
 		}
 	}
@@ -166,13 +194,14 @@ declare module com {
 		export module lite {
 			export abstract class AbstractQuery extends com.couchbase.lite.Query {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractQuery>;
+				public static DOMAIN: com.couchbase.lite.LogDomain;
 				public execute(): com.couchbase.lite.ResultSet;
+				public getDatabase(): com.couchbase.lite.AbstractDatabase;
 				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
 				public getParameters(): com.couchbase.lite.Parameters;
-				public finalize(): void;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
-				public toString(): string;
+				public prepQueryLocked(param0: com.couchbase.lite.AbstractDatabase): com.couchbase.lite.internal.core.C4Query;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public explain(): string;
 			}
@@ -183,61 +212,36 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export abstract class AbstractReplicator extends com.couchbase.lite.NetworkReachabilityListener {
+			export abstract class AbstractReplicator extends com.couchbase.lite.internal.core.BaseReplicator {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator>;
+				public createReplicatorForTarget(param0: com.couchbase.lite.Endpoint): com.couchbase.lite.internal.core.C4Replicator;
+				public getPendingDocumentIds(): java.util.Set<string>;
 				public getConfig(): com.couchbase.lite.ReplicatorConfiguration;
 				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
-				public schema(): string;
+				public start(param0: boolean): void;
+				public getMessageC4Replicator(param0: number): com.couchbase.lite.internal.core.C4Replicator;
 				public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
-				public finalize(): void;
+				public getServerCertificates(): java.util.List<java.security.cert.Certificate>;
 				public toString(): string;
+				public constructor();
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.ReplicatorChangeListener): com.couchbase.lite.ListenerToken;
 				public addDocumentReplicationListener(param0: com.couchbase.lite.DocumentReplicationListener): com.couchbase.lite.ListenerToken;
+				public handleOffline(param0: com.couchbase.lite.ReplicatorActivityLevel, param1: boolean): void;
 				public stop(): void;
+				public getLocalC4Replicator(param0: com.couchbase.lite.Database): com.couchbase.lite.internal.core.C4Replicator;
 				public start(): void;
 				public addChangeListener(param0: com.couchbase.lite.ReplicatorChangeListener): com.couchbase.lite.ListenerToken;
-				public getStatus(): com.couchbase.lite.AbstractReplicator.Status;
-				public framing(): number;
-				public resetCheckpoint(): void;
+				public getStatus(): com.couchbase.lite.ReplicatorStatus;
+				public isDocumentPending(param0: string): boolean;
+				public getRemoteC4Replicator(param0: java.net.URI): com.couchbase.lite.internal.core.C4Replicator;
 				public addDocumentReplicationListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.DocumentReplicationListener): com.couchbase.lite.ListenerToken;
 			}
 			export module AbstractReplicator {
-				export class ActivityLevel {
-					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.ActivityLevel>;
-					public static STOPPED: com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public static OFFLINE: com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public static CONNECTING: com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public static IDLE: com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public static BUSY: com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public static values(): native.Array<com.couchbase.lite.AbstractReplicator.ActivityLevel>;
-					public static valueOf(param0: string): com.couchbase.lite.AbstractReplicator.ActivityLevel;
-				}
-				export class Progress {
-					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.Progress>;
-					public getTotal(): number;
-					public toString(): string;
-					public getCompleted(): number;
-				}
-				export class ReplicatorListener extends com.couchbase.lite.internal.core.C4ReplicatorListener {
-					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.ReplicatorListener>;
-					public statusChanged(param0: com.couchbase.lite.internal.core.C4Replicator, param1: com.couchbase.lite.internal.core.C4ReplicatorStatus, param2: any): void;
-					public documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: native.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
-				}
-				export class ReplicatorProgressLevel {
-					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel>;
-					public static OVERALL: com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel;
-					public static PER_DOCUMENT: com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel;
-					public static PER_ATTACHMENT: com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel;
-					public static valueOf(param0: string): com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel;
-					public static values(): native.Array<com.couchbase.lite.AbstractReplicator.ReplicatorProgressLevel>;
-				}
-				export class Status {
-					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.Status>;
-					public getActivityLevel(): com.couchbase.lite.AbstractReplicator.ActivityLevel;
-					public toString(): string;
-					public getProgress(): com.couchbase.lite.AbstractReplicator.Progress;
-					public getError(): com.couchbase.lite.CouchbaseLiteException;
-					public constructor(param0: com.couchbase.lite.internal.core.C4ReplicatorStatus);
+				export class ReplicatorCookieStore extends com.couchbase.lite.internal.replicator.CBLCookieStore {
+					public static class: java.lang.Class<com.couchbase.lite.AbstractReplicator.ReplicatorCookieStore>;
+					public setCookie(param0: java.net.URI, param1: string): void;
+					public static parseCookies(param0: okhttp3.HttpUrl, param1: string): java.util.List<okhttp3.Cookie>;
+					public getCookies(param0: java.net.URI): string;
 				}
 			}
 		}
@@ -249,31 +253,48 @@ declare module com {
 		export module lite {
 			export abstract class AbstractReplicatorConfiguration {
 				public static class: java.lang.Class<com.couchbase.lite.AbstractReplicatorConfiguration>;
-				public readonly: boolean;
-				public target: com.couchbase.lite.Endpoint;
+				public static DISABLE_HEARTBEAT: number;
 				public setContinuous(param0: boolean): com.couchbase.lite.ReplicatorConfiguration;
-				public setPinnedServerCertificate(param0: native.Array<number>): com.couchbase.lite.ReplicatorConfiguration;
+				/** @deprecated */
+				public setReplicatorType(param0: com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType): com.couchbase.lite.ReplicatorConfiguration;
 				public setPushFilter(param0: com.couchbase.lite.ReplicationFilter): com.couchbase.lite.ReplicatorConfiguration;
+				public static verifyHeartbeat(param0: number): number;
 				public getConflictResolver(): com.couchbase.lite.ConflictResolver;
 				public setHeaders(param0: java.util.Map<string,string>): com.couchbase.lite.ReplicatorConfiguration;
-				public getPushFilter(): com.couchbase.lite.ReplicationFilter;
-				public getPullFilter(): com.couchbase.lite.ReplicationFilter;
-				public getPinnedServerCertificate(): native.Array<number>;
+				public setMaxAttemptWaitTime(param0: number): com.couchbase.lite.ReplicatorConfiguration;
+				/** @deprecated */
+				public getReplicatorType(): com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType;
+				public setHeartbeat(param0: number): com.couchbase.lite.ReplicatorConfiguration;
 				public setAuthenticator(param0: com.couchbase.lite.Authenticator): com.couchbase.lite.ReplicatorConfiguration;
-				public setReplicatorType(param0: com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType): com.couchbase.lite.ReplicatorConfiguration;
-				public getDatabase(): com.couchbase.lite.Database;
-				public isContinuous(): boolean;
+				public setType(param0: com.couchbase.lite.ReplicatorType): com.couchbase.lite.ReplicatorConfiguration;
+				public constructor(param0: com.couchbase.lite.AbstractReplicatorConfiguration);
+				public getMaxAttempts(): number;
 				public getChannels(): java.util.List<string>;
-				public getHeaders(): java.util.Map<string,string>;
 				public constructor(param0: com.couchbase.lite.Database, param1: com.couchbase.lite.Endpoint);
-				public setPullFilter(param0: com.couchbase.lite.ReplicationFilter): com.couchbase.lite.ReplicatorConfiguration;
 				public getDocumentIDs(): java.util.List<string>;
-				public setConflictResolver(param0: com.couchbase.lite.ConflictResolver): com.couchbase.lite.ReplicatorConfiguration;
+				public getPinnedServerCertificate(): androidNative.Array<number>;
 				public getAuthenticator(): com.couchbase.lite.Authenticator;
 				public setChannels(param0: java.util.List<string>): com.couchbase.lite.ReplicatorConfiguration;
-				public getReplicatorType(): com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType;
+				public setMaxAttempts(param0: number): com.couchbase.lite.ReplicatorConfiguration;
+				public isAutoPurgeEnabled(): boolean;
 				public setDocumentIDs(param0: java.util.List<string>): com.couchbase.lite.ReplicatorConfiguration;
 				public getTarget(): com.couchbase.lite.Endpoint;
+				public static copyCert(param0: androidNative.Array<number>): androidNative.Array<number>;
+				public constructor(param0: com.couchbase.lite.Database, param1: com.couchbase.lite.ReplicatorType, param2: boolean, param3: com.couchbase.lite.Authenticator, param4: java.util.Map<string,string>, param5: androidNative.Array<number>, param6: java.util.List<string>, param7: java.util.List<string>, param8: com.couchbase.lite.ReplicationFilter, param9: com.couchbase.lite.ReplicationFilter, param10: com.couchbase.lite.ConflictResolver, param11: number, param12: number, param13: number, param14: boolean, param15: com.couchbase.lite.Endpoint);
+				public getPushFilter(): com.couchbase.lite.ReplicationFilter;
+				public getPullFilter(): com.couchbase.lite.ReplicationFilter;
+				public setAutoPurgeEnabled(param0: boolean): com.couchbase.lite.ReplicatorConfiguration;
+				public toString(): string;
+				public constructor(param0: com.couchbase.lite.internal.BaseImmutableReplicatorConfiguration);
+				public setPinnedServerCertificate(param0: androidNative.Array<number>): com.couchbase.lite.ReplicatorConfiguration;
+				public getDatabase(): com.couchbase.lite.Database;
+				public isContinuous(): boolean;
+				public getHeaders(): java.util.Map<string,string>;
+				public setPullFilter(param0: com.couchbase.lite.ReplicationFilter): com.couchbase.lite.ReplicatorConfiguration;
+				public getType(): com.couchbase.lite.ReplicatorType;
+				public setConflictResolver(param0: com.couchbase.lite.ConflictResolver): com.couchbase.lite.ReplicatorConfiguration;
+				public getMaxAttemptWaitTime(): number;
+				public getHeartbeat(): number;
 			}
 			export module AbstractReplicatorConfiguration {
 				export class ReplicatorType {
@@ -282,7 +303,7 @@ declare module com {
 					public static PUSH: com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType;
 					public static PULL: com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType;
 					public static valueOf(param0: string): com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType;
-					public static values(): native.Array<com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType>;
+					public static values(): androidNative.Array<com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType>;
 				}
 			}
 		}
@@ -301,8 +322,8 @@ declare module com {
 				public getDictionary(param0: number): com.couchbase.lite.DictionaryInterface;
 				public getNumber(param0: number): java.lang.Number;
 				public iterator(): java.util.Iterator<any>;
-				public getDate(param0: number): java.util.Date;
 				public toMutable(): com.couchbase.lite.MutableArray;
+				public getDate(param0: number): java.util.Date;
 				public getBoolean(param0: number): boolean;
 				public getDictionary(param0: number): com.couchbase.lite.Dictionary;
 				public getBlob(param0: number): com.couchbase.lite.Blob;
@@ -313,6 +334,7 @@ declare module com {
 				public getValue(param0: number): any;
 				public count(): number;
 				public getInt(param0: number): number;
+				public toJSON(): string;
 				public getArray(param0: number): com.couchbase.lite.ArrayInterface;
 				public getFloat(param0: number): number;
 				public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
@@ -345,8 +367,8 @@ declare module com {
 					public static ANY: com.couchbase.lite.ArrayExpression.QuantifiesType;
 					public static ANY_AND_EVERY: com.couchbase.lite.ArrayExpression.QuantifiesType;
 					public static EVERY: com.couchbase.lite.ArrayExpression.QuantifiesType;
-					public static values(): native.Array<com.couchbase.lite.ArrayExpression.QuantifiesType>;
 					public static valueOf(param0: string): com.couchbase.lite.ArrayExpression.QuantifiesType;
+					public static values(): androidNative.Array<com.couchbase.lite.ArrayExpression.QuantifiesType>;
 				}
 			}
 		}
@@ -402,19 +424,20 @@ declare module com {
 				 */
 				public constructor(implementation: {
 					count(): number;
-					getValue(param0: number): any;
-					getString(param0: number): string;
-					getNumber(param0: number): java.lang.Number;
 					getInt(param0: number): number;
 					getLong(param0: number): number;
 					getFloat(param0: number): number;
 					getDouble(param0: number): number;
 					getBoolean(param0: number): boolean;
-					getBlob(param0: number): com.couchbase.lite.Blob;
+					getNumber(param0: number): java.lang.Number;
+					getString(param0: number): string;
 					getDate(param0: number): java.util.Date;
+					getBlob(param0: number): com.couchbase.lite.Blob;
 					getArray(param0: number): com.couchbase.lite.ArrayInterface;
 					getDictionary(param0: number): com.couchbase.lite.DictionaryInterface;
+					getValue(param0: number): any;
 					toList(): java.util.List<any>;
+					toJSON(): string;
 				});
 				public constructor();
 				public getDouble(param0: number): number;
@@ -430,6 +453,7 @@ declare module com {
 				public count(): number;
 				public getInt(param0: number): number;
 				public getArray(param0: number): com.couchbase.lite.ArrayInterface;
+				public toJSON(): string;
 				public getFloat(param0: number): number;
 			}
 		}
@@ -450,12 +474,33 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
+			export abstract class BaseDatabase {
+				public static class: java.lang.Class<com.couchbase.lite.BaseDatabase>;
+				public getBlobStore(): com.couchbase.lite.internal.core.C4BlobStore;
+				public mustBeOpen(): void;
+				public getOpenC4DbLocked(): com.couchbase.lite.internal.core.C4Database;
+				public isOpen(): boolean;
+				public setC4DatabaseLocked(param0: com.couchbase.lite.internal.core.C4Database): void;
+				public getDbLock(): any;
+				public constructor();
+				public getDbPath(): string;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
 			export class BasicAuthenticator extends com.couchbase.lite.Authenticator {
 				public static class: java.lang.Class<com.couchbase.lite.BasicAuthenticator>;
+				public finalize(): void;
 				public getUsername(): string;
+				public getPasswordChars(): androidNative.Array<string>;
+				/** @deprecated */
 				public getPassword(): string;
-				public constructor(param0: string, param1: string);
 				public constructor();
+				public constructor(param0: string, param1: androidNative.Array<string>);
 			}
 		}
 	}
@@ -466,18 +511,22 @@ declare module com {
 		export module lite {
 			export class Blob extends com.couchbase.lite.internal.fleece.FLEncodable {
 				public static class: java.lang.Class<com.couchbase.lite.Blob>;
+				public static ENCODER_ARG_DB: string;
+				public static ENCODER_ARG_QUERY_PARAM: string;
 				public getContentType(): string;
 				public digest(): string;
 				public constructor(param0: string, param1: java.net.URL);
 				public length(): number;
 				public finalize(): void;
-				public getContent(): native.Array<number>;
 				public toString(): string;
 				public getContentStream(): java.io.InputStream;
+				public getContent(): androidNative.Array<number>;
 				public getProperties(): java.util.Map<string,any>;
 				public hashCode(): number;
+				public constructor(param0: string, param1: androidNative.Array<number>);
 				public equals(param0: any): boolean;
-				public constructor(param0: string, param1: native.Array<number>);
+				public static isBlob(param0: java.util.Map<string,any>): boolean;
+				public toJSON(): string;
 				public constructor(param0: string, param1: java.io.InputStream);
 				public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
 			}
@@ -486,12 +535,12 @@ declare module com {
 					public static class: java.lang.Class<com.couchbase.lite.Blob.BlobInputStream>;
 					public available(): number;
 					public read(): number;
-					public read(param0: native.Array<number>, param1: number, param2: number): number;
 					public reset(): void;
 					public markSupported(): boolean;
-					public read(param0: native.Array<number>): number;
 					public skip(param0: number): number;
 					public close(): void;
+					public read(param0: androidNative.Array<number>, param1: number, param2: number): number;
+					public read(param0: androidNative.Array<number>): number;
 					public mark(param0: number): void;
 				}
 			}
@@ -505,15 +554,34 @@ declare module com {
 			export class BuildConfig {
 				public static class: java.lang.Class<com.couchbase.lite.BuildConfig>;
 				public static DEBUG: boolean;
-				public static APPLICATION_ID: string;
+				public static LIBRARY_PACKAGE_NAME: string;
 				public static BUILD_TYPE: string;
-				public static FLAVOR: string;
-				public static VERSION_CODE: number;
-				public static VERSION_NAME: string;
 				public static BUILD_COMMIT: string;
 				public static BUILD_TIME: string;
+				public static CBL_DEBUG: boolean;
 				public static ENTERPRISE: boolean;
+				public static VERSION_NAME: string;
 				public constructor();
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export abstract class BuilderQuery extends com.couchbase.lite.AbstractQuery {
+				public static class: java.lang.Class<com.couchbase.lite.BuilderQuery>;
+				public getDatabase(): com.couchbase.lite.AbstractDatabase;
+				public execute(): com.couchbase.lite.ResultSet;
+				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
+				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
+				public getParameters(): com.couchbase.lite.Parameters;
+				public prepQueryLocked(param0: com.couchbase.lite.AbstractDatabase): com.couchbase.lite.internal.core.C4Query;
+				public setParameters(param0: com.couchbase.lite.Parameters): void;
+				public toString(): string;
+				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
+				public explain(): string;
 			}
 		}
 	}
@@ -541,7 +609,7 @@ declare module com {
 					public static ASSERTION_FAILED: number;
 					public static UNIMPLEMENTED: number;
 					public static UNSUPPORTED_ENCRYPTION: number;
-					public static BAD_REVISIONID: number;
+					public static BAD_REVISION_ID: number;
 					public static CORRUPT_REVISION_DATA: number;
 					public static NOT_OPEN: number;
 					public static NOT_FOUND: number;
@@ -551,13 +619,13 @@ declare module com {
 					public static CANT_OPEN_FILE: number;
 					public static IO_ERROR: number;
 					public static MEMORY_ERROR: number;
-					public static NOT_WRITEABLE: number;
+					public static NOT_WRITABLE: number;
 					public static CORRUPT_DATA: number;
 					public static BUSY: number;
 					public static NOT_IN_TRANSACTION: number;
 					public static TRANSACTION_NOT_CLOSED: number;
 					public static UNSUPPORTED: number;
-					public static NOT_A_DATABSE_FILE: number;
+					public static NOT_A_DATABASE_FILE: number;
 					public static WRONG_FORMAT: number;
 					public static CRYPTO: number;
 					public static INVALID_QUERY: number;
@@ -568,7 +636,7 @@ declare module com {
 					public static DATABASE_TOO_NEW: number;
 					public static BAD_DOC_ID: number;
 					public static CANT_UPGRADE_DATABASE: number;
-					public static NETWORK_BASE: number;
+					public static NETWORK_OFFSET: number;
 					public static DNS_FAILURE: number;
 					public static UNKNOWN_HOST: number;
 					public static TIMEOUT: number;
@@ -592,7 +660,7 @@ declare module com {
 					public static HTTP_INTERNAL_SERVER_ERROR: number;
 					public static HTTP_NOT_IMPLEMENTED: number;
 					public static HTTP_SERVICE_UNAVAILABLE: number;
-					public static WEB_SOCKET_BASE: number;
+					public static WEB_SOCKET_NORMAL_CLOSE: number;
 					public static WEB_SOCKET_GOING_AWAY: number;
 					public static WEB_SOCKET_PROTOCOL_ERROR: number;
 					public static WEB_SOCKET_DATA_ERROR: number;
@@ -602,12 +670,15 @@ declare module com {
 					public static WEB_SOCKET_MESSAGE_TOO_BIG: number;
 					public static WEB_SOCKET_MISSING_EXTENSION: number;
 					public static WEB_SOCKET_CANT_FULFILL: number;
+					public static WEB_SOCKET_TLS_FAILURE: number;
+					public static WEB_SOCKET_USER: number;
 					public static WEB_SOCKET_CLOSE_USER_TRANSIENT: number;
 					public static WEB_SOCKET_CLOSE_USER_PERMANENT: number;
 				}
 				export class Domain {
 					public static class: java.lang.Class<com.couchbase.lite.CBLError.Domain>;
 					public static CBLITE: string;
+					public static POSIX: string;
 					public static SQLITE: string;
 					public static FLEECE: string;
 				}
@@ -661,20 +732,28 @@ declare module com {
 		export module lite {
 			export class Collation {
 				public static class: java.lang.Class<com.couchbase.lite.Collation>;
+				public setIgnoreAccents(param0: boolean): com.couchbase.lite.Collation;
 				public static ascii(): com.couchbase.lite.Collation.ASCII;
+				public setLocale(param0: string): com.couchbase.lite.Collation;
+				public constructor(param0: boolean, param1: string);
 				public static unicode(): com.couchbase.lite.Collation.Unicode;
+				public setIgnoreCase(param0: boolean): com.couchbase.lite.Collation;
 				public toString(): string;
 			}
 			export module Collation {
 				export class ASCII extends com.couchbase.lite.Collation {
 					public static class: java.lang.Class<com.couchbase.lite.Collation.ASCII>;
-					public ignoreCase(param0: boolean): com.couchbase.lite.Collation.ASCII;
+					public setIgnoreCase(param0: boolean): com.couchbase.lite.Collation.ASCII;
+					public setIgnoreCase(param0: boolean): com.couchbase.lite.Collation;
 				}
 				export class Unicode extends com.couchbase.lite.Collation {
 					public static class: java.lang.Class<com.couchbase.lite.Collation.Unicode>;
-					public locale(param0: string): com.couchbase.lite.Collation.Unicode;
-					public ignoreCase(param0: boolean): com.couchbase.lite.Collation.Unicode;
-					public ignoreAccents(param0: boolean): com.couchbase.lite.Collation.Unicode;
+					public setLocale(param0: string): com.couchbase.lite.Collation;
+					public setIgnoreAccents(param0: boolean): com.couchbase.lite.Collation.Unicode;
+					public setIgnoreCase(param0: boolean): com.couchbase.lite.Collation;
+					public setIgnoreAccents(param0: boolean): com.couchbase.lite.Collation;
+					public setIgnoreCase(param0: boolean): com.couchbase.lite.Collation.Unicode;
+					public setLocale(param0: string): com.couchbase.lite.Collation.Unicode;
 				}
 			}
 		}
@@ -688,7 +767,7 @@ declare module com {
 				public static class: java.lang.Class<com.couchbase.lite.ConcurrencyControl>;
 				public static LAST_WRITE_WINS: com.couchbase.lite.ConcurrencyControl;
 				public static FAIL_ON_CONFLICT: com.couchbase.lite.ConcurrencyControl;
-				public static values(): native.Array<com.couchbase.lite.ConcurrencyControl>;
+				public static values(): androidNative.Array<com.couchbase.lite.ConcurrencyControl>;
 				public static valueOf(param0: string): com.couchbase.lite.ConcurrencyControl;
 				public getValue(): number;
 			}
@@ -766,7 +845,8 @@ declare module com {
 		export module lite {
 			export class CouchbaseLite {
 				public static class: java.lang.Class<com.couchbase.lite.CouchbaseLite>;
-				public static getExecutionService(): com.couchbase.lite.internal.ExecutionService;
+				public static init(param0: globalAndroid.content.Context, param1: boolean, param2: java.io.File, param3: java.io.File): void;
+				public static init(param0: globalAndroid.content.Context, param1: boolean): void;
 				public static init(param0: globalAndroid.content.Context): void;
 			}
 		}
@@ -779,20 +859,31 @@ declare module com {
 			export class CouchbaseLiteException {
 				public static class: java.lang.Class<com.couchbase.lite.CouchbaseLiteException>;
 				/** @deprecated */
-				public constructor(param0: string, param1: number, param2: java.util.Map<string,any>);
+				public constructor(param0: string, param1: number, param2: java.lang.Exception);
 				public constructor(param0: string, param1: string, param2: number);
 				public getInfo(): java.util.Map<string,any>;
-				public constructor(param0: string, param1: java.lang.Throwable, param2: string, param3: number);
-				/** @deprecated */
-				public constructor(param0: string, param1: number, param2: java.lang.Throwable);
 				public getCode(): number;
-				public getDomain(): string;
-				public constructor(param0: com.couchbase.lite.internal.CBLInternalException);
+				public static convertC4Error(param0: com.couchbase.lite.internal.core.C4Error): com.couchbase.lite.CouchbaseLiteException;
 				public toString(): string;
-				public constructor(param0: java.lang.Throwable);
+				public static convertException(param0: com.couchbase.lite.LiteCoreException, param1: string): com.couchbase.lite.CouchbaseLiteException;
+				public constructor(param0: string);
+				/** @deprecated */
+				public constructor(param0: com.couchbase.lite.internal.CBLInternalException);
+				public constructor();
+				/** @deprecated */
+				public constructor(param0: string, param1: number, param2: java.util.Map<string,any>);
+				public static toCouchbaseLiteException(param0: number, param1: number, param2: number): com.couchbase.lite.CouchbaseLiteException;
+				public constructor(param0: string, param1: java.lang.Exception);
+				public getDomain(): string;
 				/** @deprecated */
 				public constructor(param0: string, param1: number);
-				public constructor(param0: string);
+				public static convertException(param0: com.couchbase.lite.LiteCoreException): com.couchbase.lite.CouchbaseLiteException;
+				public constructor(param0: string, param1: com.couchbase.lite.internal.CBLInternalException);
+				public constructor(param0: string, param1: java.lang.Exception, param2: string, param3: number);
+				public constructor(param0: string, param1: java.lang.Exception, param2: string, param3: number, param4: java.util.Map<string,any>);
+				public static toCouchbaseLiteException(param0: number, param1: number, param2: string, param3: java.lang.Exception): com.couchbase.lite.CouchbaseLiteException;
+				/** @deprecated */
+				public constructor(param0: java.lang.Exception);
 			}
 		}
 	}
@@ -803,6 +894,7 @@ declare module com {
 		export module lite {
 			export class DataSource {
 				public static class: java.lang.Class<com.couchbase.lite.DataSource>;
+				public alias: string;
 				public static database(param0: com.couchbase.lite.Database): com.couchbase.lite.DataSource.As;
 			}
 			export module DataSource {
@@ -820,11 +912,12 @@ declare module com {
 		export module lite {
 			export class Database extends com.couchbase.lite.AbstractDatabase {
 				public static class: java.lang.Class<com.couchbase.lite.Database>;
-				public static copy(param0: java.io.File, param1: string, param2: com.couchbase.lite.DatabaseConfiguration, param3: number, param4: native.Array<number>): void;
-				public constructor(param0: com.couchbase.lite.internal.core.C4Database);
 				public constructor(param0: string, param1: com.couchbase.lite.DatabaseConfiguration);
+				public static copy(param0: java.io.File, param1: string, param2: string, param3: number, param4: androidNative.Array<number>): void;
 				public static copy(param0: java.io.File, param1: string, param2: com.couchbase.lite.DatabaseConfiguration): void;
 				public constructor(param0: string);
+				public constructor(param0: string, param1: com.couchbase.lite.internal.ImmutableDatabaseConfiguration);
+				public constructor();
 			}
 		}
 	}
@@ -869,11 +962,11 @@ declare module com {
 		export module lite {
 			export class DatabaseConfiguration extends com.couchbase.lite.AbstractDatabaseConfiguration {
 				public static class: java.lang.Class<com.couchbase.lite.DatabaseConfiguration>;
-				public setDirectory(param0: string): com.couchbase.lite.AbstractDatabaseConfiguration;
-				public setDirectory(param0: string): com.couchbase.lite.DatabaseConfiguration;
+				public constructor(param0: com.couchbase.lite.internal.BaseImmutableDatabaseConfiguration);
 				public getDatabaseConfiguration(): com.couchbase.lite.DatabaseConfiguration;
 				public constructor(param0: com.couchbase.lite.AbstractDatabaseConfiguration);
 				public constructor(param0: com.couchbase.lite.DatabaseConfiguration);
+				public constructor(param0: string);
 				public constructor();
 			}
 		}
@@ -920,6 +1013,7 @@ declare module com {
 				public getDate(param0: string): java.util.Date;
 				public iterator(): java.util.Iterator<string>;
 				public count(): number;
+				public toJSON(): string;
 				public toMap(): java.util.Map<string,any>;
 				public getInt(param0: string): number;
 				public getArray(param0: string): com.couchbase.lite.Array;
@@ -938,21 +1032,22 @@ declare module com {
 				 */
 				public constructor(implementation: {
 					count(): number;
-					getKeys(): java.util.List<string>;
-					getValue(param0: string): any;
-					getString(param0: string): string;
-					getNumber(param0: string): java.lang.Number;
+					contains(param0: string): boolean;
 					getInt(param0: string): number;
 					getLong(param0: string): number;
 					getFloat(param0: string): number;
 					getDouble(param0: string): number;
 					getBoolean(param0: string): boolean;
-					getBlob(param0: string): com.couchbase.lite.Blob;
+					getNumber(param0: string): java.lang.Number;
+					getString(param0: string): string;
 					getDate(param0: string): java.util.Date;
+					getBlob(param0: string): com.couchbase.lite.Blob;
 					getArray(param0: string): com.couchbase.lite.ArrayInterface;
 					getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
+					getValue(param0: string): any;
+					getKeys(): java.util.List<string>;
 					toMap(): java.util.Map<string,any>;
-					contains(param0: string): boolean;
+					toJSON(): string;
 				});
 				public constructor();
 				public getLong(param0: string): number;
@@ -960,15 +1055,16 @@ declare module com {
 				public getValue(param0: string): any;
 				public getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
 				public getNumber(param0: string): java.lang.Number;
+				public contains(param0: string): boolean;
 				public getDouble(param0: string): number;
 				public getArray(param0: string): com.couchbase.lite.ArrayInterface;
-				public contains(param0: string): boolean;
 				public getDate(param0: string): java.util.Date;
 				public getBoolean(param0: string): boolean;
-				public getString(param0: string): string;
 				public getFloat(param0: string): number;
+				public getString(param0: string): string;
 				public count(): number;
 				public getBlob(param0: string): com.couchbase.lite.Blob;
+				public toJSON(): string;
 				public toMap(): java.util.Map<string,any>;
 				public getInt(param0: string): number;
 			}
@@ -979,9 +1075,8 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class DocContext extends com.couchbase.lite.internal.fleece.MContext {
+			export class DocContext extends com.couchbase.lite.internal.DbContext {
 				public static class: java.lang.Class<com.couchbase.lite.DocContext>;
-				public finalize(): void;
 			}
 		}
 	}
@@ -994,7 +1089,7 @@ declare module com {
 				public static class: java.lang.Class<com.couchbase.lite.Document>;
 				public getId(): string;
 				public getSequence(): number;
-				public finalize(): void;
+				public setContent(param0: com.couchbase.lite.Dictionary): void;
 				public getKeys(): java.util.List<string>;
 				public toMutable(): com.couchbase.lite.MutableDocument;
 				public getValue(param0: string): any;
@@ -1010,13 +1105,15 @@ declare module com {
 				public getFloat(param0: string): number;
 				public getBlob(param0: string): com.couchbase.lite.Blob;
 				public getLong(param0: string): number;
+				public constructor(param0: com.couchbase.lite.Database, param1: string, param2: com.couchbase.lite.internal.core.C4Document, param3: boolean);
 				public toString(): string;
+				public getContent(): com.couchbase.lite.Dictionary;
 				public getDouble(param0: string): number;
 				public getArray(param0: string): com.couchbase.lite.ArrayInterface;
-				public constructor(param0: com.couchbase.lite.Database, param1: string, param2: com.couchbase.lite.internal.core.C4Document);
 				public getDate(param0: string): java.util.Date;
 				public iterator(): java.util.Iterator<string>;
 				public count(): number;
+				public toJSON(): string;
 				public toMap(): java.util.Map<string,any>;
 				public getInt(param0: string): number;
 				public getArray(param0: string): com.couchbase.lite.Array;
@@ -1073,22 +1170,12 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class DocumentExpirationStrategy {
-				public static class: java.lang.Class<com.couchbase.lite.DocumentExpirationStrategy>;
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
 			export class DocumentFlag {
 				public static class: java.lang.Class<com.couchbase.lite.DocumentFlag>;
-				public static DocumentFlagsDeleted: com.couchbase.lite.DocumentFlag;
-				public static DocumentFlagsAccessRemoved: com.couchbase.lite.DocumentFlag;
-				public static values(): native.Array<com.couchbase.lite.DocumentFlag>;
+				public static DELETED: com.couchbase.lite.DocumentFlag;
+				public static ACCESS_REMOVED: com.couchbase.lite.DocumentFlag;
 				public rawValue(): number;
+				public static values(): androidNative.Array<com.couchbase.lite.DocumentFlag>;
 				public static valueOf(param0: string): com.couchbase.lite.DocumentFlag;
 			}
 		}
@@ -1166,7 +1253,6 @@ declare module com {
 				public static string(param0: string): com.couchbase.lite.Expression;
 				public isNot(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public collate(param0: com.couchbase.lite.Collation): com.couchbase.lite.Expression;
-				public in(param0: native.Array<com.couchbase.lite.Expression>): com.couchbase.lite.Expression;
 				public add(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public constructor();
 				public static booleanValue(param0: boolean): com.couchbase.lite.Expression;
@@ -1174,13 +1260,14 @@ declare module com {
 				public static number(param0: java.lang.Number): com.couchbase.lite.Expression;
 				public static map(param0: java.util.Map<string,any>): com.couchbase.lite.Expression;
 				public static doubleValue(param0: number): com.couchbase.lite.Expression;
-				public isNullOrMissing(): com.couchbase.lite.Expression;
 				public static all(): com.couchbase.lite.PropertyExpression;
 				public greaterThan(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
+				public isValued(): com.couchbase.lite.Expression;
 				public static date(param0: java.util.Date): com.couchbase.lite.Expression;
 				public divide(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public notEqualTo(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public greaterThanOrEqualTo(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
+				public in(param0: androidNative.Array<com.couchbase.lite.Expression>): com.couchbase.lite.Expression;
 				public like(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public subtract(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public static not(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
@@ -1188,15 +1275,19 @@ declare module com {
 				public and(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public or(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public lessThanOrEqualTo(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
+				public isNotValued(): com.couchbase.lite.Expression;
 				public toString(): string;
 				public static list(param0: java.util.List<any>): com.couchbase.lite.Expression;
 				public lessThan(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public static value(param0: any): com.couchbase.lite.Expression;
 				public static longValue(param0: number): com.couchbase.lite.Expression;
-				public notNullOrMissing(): com.couchbase.lite.Expression;
 				public regex(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public equalTo(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 				public static intValue(param0: number): com.couchbase.lite.Expression;
+				/** @deprecated */
+				public isNullOrMissing(): com.couchbase.lite.Expression;
+				/** @deprecated */
+				public notNullOrMissing(): com.couchbase.lite.Expression;
 				public multiply(param0: com.couchbase.lite.Expression): com.couchbase.lite.Expression;
 			}
 			export module Expression {
@@ -1227,8 +1318,8 @@ declare module com {
 						public static NotEqualTo: com.couchbase.lite.Expression.BinaryExpression.OpType;
 						public static Subtract: com.couchbase.lite.Expression.BinaryExpression.OpType;
 						public static RegexLike: com.couchbase.lite.Expression.BinaryExpression.OpType;
-						public static values(): native.Array<com.couchbase.lite.Expression.BinaryExpression.OpType>;
 						public static valueOf(param0: string): com.couchbase.lite.Expression.BinaryExpression.OpType;
+						public static values(): androidNative.Array<com.couchbase.lite.Expression.BinaryExpression.OpType>;
 					}
 				}
 				export class CollationExpression extends com.couchbase.lite.Expression {
@@ -1244,7 +1335,7 @@ declare module com {
 						public static Or: com.couchbase.lite.Expression.CompoundExpression.OpType;
 						public static Not: com.couchbase.lite.Expression.CompoundExpression.OpType;
 						public static valueOf(param0: string): com.couchbase.lite.Expression.CompoundExpression.OpType;
-						public static values(): native.Array<com.couchbase.lite.Expression.CompoundExpression.OpType>;
+						public static values(): androidNative.Array<com.couchbase.lite.Expression.CompoundExpression.OpType>;
 					}
 				}
 				export class FunctionExpression extends com.couchbase.lite.Expression {
@@ -1263,8 +1354,9 @@ declare module com {
 						public static NotMissing: com.couchbase.lite.Expression.UnaryExpression.OpType;
 						public static NotNull: com.couchbase.lite.Expression.UnaryExpression.OpType;
 						public static Null: com.couchbase.lite.Expression.UnaryExpression.OpType;
+						public static Valued: com.couchbase.lite.Expression.UnaryExpression.OpType;
+						public static values(): androidNative.Array<com.couchbase.lite.Expression.UnaryExpression.OpType>;
 						public static valueOf(param0: string): com.couchbase.lite.Expression.UnaryExpression.OpType;
-						public static values(): native.Array<com.couchbase.lite.Expression.UnaryExpression.OpType>;
 					}
 				}
 				export class ValueExpression extends com.couchbase.lite.Expression {
@@ -1303,21 +1395,21 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class From extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.JoinRouter, com.couchbase.lite.WhereRouter, com.couchbase.lite.GroupByRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
+			export class From extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.JoinRouter, com.couchbase.lite.WhereRouter, com.couchbase.lite.GroupByRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.From>;
 				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
+				public join(param0: androidNative.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public explain(): string;
 				public execute(): com.couchbase.lite.ResultSet;
 				public limit(param0: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
 				public limit(param0: com.couchbase.lite.Expression, param1: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
 				public getParameters(): com.couchbase.lite.Parameters;
-				public join(param0: native.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
+				public groupBy(param0: androidNative.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
 				public where(param0: com.couchbase.lite.Expression): com.couchbase.lite.Where;
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
-				public groupBy(param0: native.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 			}
 		}
 	}
@@ -1346,7 +1438,9 @@ declare module com {
 		export module lite {
 			export class FullTextExpression {
 				public static class: java.lang.Class<com.couchbase.lite.FullTextExpression>;
+				/** @deprecated */
 				public match(param0: string): com.couchbase.lite.Expression;
+				/** @deprecated */
 				public static index(param0: string): com.couchbase.lite.FullTextExpression;
 			}
 			export module FullTextExpression {
@@ -1363,6 +1457,7 @@ declare module com {
 		export module lite {
 			export class FullTextFunction {
 				public static class: java.lang.Class<com.couchbase.lite.FullTextFunction>;
+				public static match(param0: string, param1: string): com.couchbase.lite.Expression;
 				public static rank(param0: string): com.couchbase.lite.Expression;
 			}
 		}
@@ -1372,10 +1467,24 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class FullTextIndex extends com.couchbase.lite.AbstractIndex {
+			export class FullTextIndex extends com.couchbase.lite.Index {
 				public static class: java.lang.Class<com.couchbase.lite.FullTextIndex>;
 				public setLanguage(param0: string): com.couchbase.lite.FullTextIndex;
 				public ignoreAccents(param0: boolean): com.couchbase.lite.FullTextIndex;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class FullTextIndexConfiguration extends com.couchbase.lite.IndexConfiguration {
+				public static class: java.lang.Class<com.couchbase.lite.FullTextIndexConfiguration>;
+				public setLanguage(param0: string): com.couchbase.lite.FullTextIndexConfiguration;
+				public constructor(param0: com.couchbase.lite.AbstractIndex.IndexType, param1: com.couchbase.lite.AbstractIndex.QueryLanguage);
+				public ignoreAccents(param0: boolean): com.couchbase.lite.FullTextIndexConfiguration;
+				public constructor(param0: androidNative.Array<string>);
 			}
 		}
 	}
@@ -1405,7 +1514,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class GroupBy extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.HavingRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
+			export class GroupBy extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.HavingRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.GroupBy>;
 				public having(param0: com.couchbase.lite.Expression): com.couchbase.lite.Having;
 				public execute(): com.couchbase.lite.ResultSet;
@@ -1415,7 +1524,7 @@ declare module com {
 				public limit(param0: com.couchbase.lite.Expression, param1: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
 				public getParameters(): com.couchbase.lite.Parameters;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public explain(): string;
 			}
@@ -1432,10 +1541,10 @@ declare module com {
 				 * Constructs a new instance of the com.couchbase.lite.GroupByRouter interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 				 */
 				public constructor(implementation: {
-					groupBy(param0: native.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
+					groupBy(param0: androidNative.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
 				});
 				public constructor();
-				public groupBy(param0: native.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
+				public groupBy(param0: androidNative.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
 			}
 		}
 	}
@@ -1444,7 +1553,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Having extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
+			export class Having extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.Having>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public limit(param0: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
@@ -1453,7 +1562,7 @@ declare module com {
 				public limit(param0: com.couchbase.lite.Expression, param1: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
 				public getParameters(): com.couchbase.lite.Parameters;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public explain(): string;
 			}
@@ -1482,14 +1591,8 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Index {
+			export abstract class Index extends com.couchbase.lite.AbstractIndex {
 				public static class: java.lang.Class<com.couchbase.lite.Index>;
-				/**
-				 * Constructs a new instance of the com.couchbase.lite.Index interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-				 */
-				public constructor(implementation: {
-				});
-				public constructor();
 			}
 		}
 	}
@@ -1509,13 +1612,8 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class IndexType {
-				public static class: java.lang.Class<com.couchbase.lite.IndexType>;
-				public static Value: com.couchbase.lite.IndexType;
-				public static FullText: com.couchbase.lite.IndexType;
-				public static Predictive: com.couchbase.lite.IndexType;
-				public static values(): native.Array<com.couchbase.lite.IndexType>;
-				public static valueOf(param0: string): com.couchbase.lite.IndexType;
+			export class IndexConfiguration extends com.couchbase.lite.AbstractIndex {
+				public static class: java.lang.Class<com.couchbase.lite.IndexConfiguration>;
 			}
 		}
 	}
@@ -1543,7 +1641,7 @@ declare module com {
 					public static LEFT_OUTER: com.couchbase.lite.Join.Type;
 					public static CROSS: com.couchbase.lite.Join.Type;
 					public static valueOf(param0: string): com.couchbase.lite.Join.Type;
-					public static values(): native.Array<com.couchbase.lite.Join.Type>;
+					public static values(): androidNative.Array<com.couchbase.lite.Join.Type>;
 					public getTag(): string;
 				}
 			}
@@ -1560,10 +1658,10 @@ declare module com {
 				 * Constructs a new instance of the com.couchbase.lite.JoinRouter interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 				 */
 				public constructor(implementation: {
-					join(param0: native.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
+					join(param0: androidNative.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
 				});
 				public constructor();
-				public join(param0: native.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
+				public join(param0: androidNative.Array<com.couchbase.lite.Join>): com.couchbase.lite.Joins;
 			}
 		}
 	}
@@ -1572,7 +1670,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Joins extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.WhereRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
+			export class Joins extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.WhereRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.Joins>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public limit(param0: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
@@ -1582,7 +1680,7 @@ declare module com {
 				public getParameters(): com.couchbase.lite.Parameters;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
 				public where(param0: com.couchbase.lite.Expression): com.couchbase.lite.Where;
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
 				public explain(): string;
 			}
@@ -1593,7 +1691,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Limit extends com.couchbase.lite.AbstractQuery {
+			export class Limit extends com.couchbase.lite.BuilderQuery {
 				public static class: java.lang.Class<com.couchbase.lite.Limit>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
@@ -1666,7 +1764,6 @@ declare module com {
 			export class LiveQuery extends com.couchbase.lite.DatabaseChangeListener {
 				public static class: java.lang.Class<com.couchbase.lite.LiveQuery>;
 				public changed(param0: com.couchbase.lite.DatabaseChange): void;
-				public finalize(): void;
 				public toString(): string;
 				public changed(param0: any): void;
 			}
@@ -1676,7 +1773,7 @@ declare module com {
 					public static STOPPED: com.couchbase.lite.LiveQuery.State;
 					public static STARTED: com.couchbase.lite.LiveQuery.State;
 					public static SCHEDULED: com.couchbase.lite.LiveQuery.State;
-					public static values(): native.Array<com.couchbase.lite.LiveQuery.State>;
+					public static values(): androidNative.Array<com.couchbase.lite.LiveQuery.State>;
 					public static valueOf(param0: string): com.couchbase.lite.LiveQuery.State;
 				}
 			}
@@ -1703,13 +1800,13 @@ declare module com {
 		export module lite {
 			export class LogDomain {
 				public static class: java.lang.Class<com.couchbase.lite.LogDomain>;
-				public static ALL: com.couchbase.lite.LogDomain;
 				public static DATABASE: com.couchbase.lite.LogDomain;
 				public static QUERY: com.couchbase.lite.LogDomain;
 				public static REPLICATOR: com.couchbase.lite.LogDomain;
 				public static NETWORK: com.couchbase.lite.LogDomain;
+				public static LISTENER: com.couchbase.lite.LogDomain;
 				public static ALL_DOMAINS: java.util.EnumSet<com.couchbase.lite.LogDomain>;
-				public static values(): native.Array<com.couchbase.lite.LogDomain>;
+				public static values(): androidNative.Array<com.couchbase.lite.LogDomain>;
 				public static valueOf(param0: string): com.couchbase.lite.LogDomain;
 			}
 		}
@@ -1729,8 +1826,8 @@ declare module com {
 				public getMaxSize(): number;
 				public getMaxRotateCount(): number;
 				public setMaxSize(param0: number): com.couchbase.lite.LogFileConfiguration;
-				public constructor(param0: com.couchbase.lite.LogFileConfiguration);
 				public constructor(param0: string);
+				public constructor(param0: com.couchbase.lite.LogFileConfiguration);
 				public setUsePlaintext(param0: boolean): com.couchbase.lite.LogFileConfiguration;
 				public getDirectory(): string;
 			}
@@ -1749,9 +1846,8 @@ declare module com {
 				public static WARNING: com.couchbase.lite.LogLevel;
 				public static ERROR: com.couchbase.lite.LogLevel;
 				public static NONE: com.couchbase.lite.LogLevel;
-				public static values(): native.Array<com.couchbase.lite.LogLevel>;
+				public static values(): androidNative.Array<com.couchbase.lite.LogLevel>;
 				public static valueOf(param0: string): com.couchbase.lite.LogLevel;
-				public getValue(): number;
 				public toString(): string;
 			}
 		}
@@ -1794,9 +1890,27 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
+			export class MaintenanceType {
+				public static class: java.lang.Class<com.couchbase.lite.MaintenanceType>;
+				public static REINDEX: com.couchbase.lite.MaintenanceType;
+				public static COMPACT: com.couchbase.lite.MaintenanceType;
+				public static INTEGRITY_CHECK: com.couchbase.lite.MaintenanceType;
+				public static OPTIMIZE: com.couchbase.lite.MaintenanceType;
+				public static FULL_OPTIMIZE: com.couchbase.lite.MaintenanceType;
+				public static values(): androidNative.Array<com.couchbase.lite.MaintenanceType>;
+				public static valueOf(param0: string): com.couchbase.lite.MaintenanceType;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
 			export class Meta {
 				public static class: java.lang.Class<com.couchbase.lite.Meta>;
 				public static id: com.couchbase.lite.MetaExpression;
+				public static revisionID: com.couchbase.lite.MetaExpression;
 				public static sequence: com.couchbase.lite.MetaExpression;
 				public static deleted: com.couchbase.lite.MetaExpression;
 				public static expiration: com.couchbase.lite.MetaExpression;
@@ -1824,7 +1938,9 @@ declare module com {
 				public insertBoolean(param0: number, param1: boolean): com.couchbase.lite.MutableArrayInterface;
 				public addDictionary(param0: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
 				public insertArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
+				public setJSON(param0: string): com.couchbase.lite.MutableArray;
 				public insertDictionary(param0: number, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArray;
+				public setJSON(param0: string): com.couchbase.lite.MutableArrayInterface;
 				public setDate(param0: number, param1: java.util.Date): com.couchbase.lite.MutableArray;
 				public insertNumber(param0: number, param1: java.lang.Number): com.couchbase.lite.MutableArray;
 				public setDouble(param0: number, param1: number): com.couchbase.lite.MutableArray;
@@ -1840,11 +1956,13 @@ declare module com {
 				public addFloat(param0: number): com.couchbase.lite.MutableArray;
 				public insertDouble(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 				public insertLong(param0: number, param1: number): com.couchbase.lite.MutableArray;
+				public toJSON(): string;
 				public setValue(param0: number, param1: any): com.couchbase.lite.MutableArray;
 				public getString(param0: number): string;
 				public getNumber(param0: number): java.lang.Number;
 				public setString(param0: number, param1: string): com.couchbase.lite.MutableArray;
 				public insertInt(param0: number, param1: number): com.couchbase.lite.MutableArray;
+				public constructor(param0: string);
 				public insertValue(param0: number, param1: any): com.couchbase.lite.MutableArray;
 				public addInt(param0: number): com.couchbase.lite.MutableArray;
 				public setData(param0: java.util.List<any>): com.couchbase.lite.MutableArrayInterface;
@@ -1881,14 +1999,14 @@ declare module com {
 				public setLong(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 				public addString(param0: string): com.couchbase.lite.MutableArray;
 				public addDouble(param0: number): com.couchbase.lite.MutableArray;
-				public setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 				public setDate(param0: number, param1: java.util.Date): com.couchbase.lite.MutableArrayInterface;
+				public setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 				public addInt(param0: number): com.couchbase.lite.MutableArrayInterface;
 				public insertArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArray;
-				public insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 				public getArray(param0: number): com.couchbase.lite.MutableArrayInterface;
-				public addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+				public insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 				public addBoolean(param0: boolean): com.couchbase.lite.MutableArrayInterface;
+				public addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
 				public getDate(param0: number): java.util.Date;
 				public getBoolean(param0: number): boolean;
 				public insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArray;
@@ -1934,62 +2052,64 @@ declare module com {
 				 * Constructs a new instance of the com.couchbase.lite.MutableArrayInterface interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 				 */
 				public constructor(implementation: {
-					setData(param0: java.util.List<any>): com.couchbase.lite.MutableArrayInterface;
-					setValue(param0: number, param1: any): com.couchbase.lite.MutableArrayInterface;
-					setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
-					setNumber(param0: number, param1: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+					getArray(param0: number): com.couchbase.lite.MutableArrayInterface;
+					getDictionary(param0: number): com.couchbase.lite.MutableDictionaryInterface;
+					remove(param0: number): com.couchbase.lite.MutableArrayInterface;
 					setInt(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					setLong(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					setFloat(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					setDouble(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					setBoolean(param0: number, param1: boolean): com.couchbase.lite.MutableArrayInterface;
-					setBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 					setDate(param0: number, param1: java.util.Date): com.couchbase.lite.MutableArrayInterface;
+					setBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 					setArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
 					setDictionary(param0: number, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
-					addValue(param0: any): com.couchbase.lite.MutableArrayInterface;
-					addString(param0: string): com.couchbase.lite.MutableArrayInterface;
-					addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+					setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
+					setNumber(param0: number, param1: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+					setValue(param0: number, param1: any): com.couchbase.lite.MutableArrayInterface;
+					setData(param0: java.util.List<any>): com.couchbase.lite.MutableArrayInterface;
+					setJSON(param0: string): com.couchbase.lite.MutableArrayInterface;
 					addInt(param0: number): com.couchbase.lite.MutableArrayInterface;
 					addLong(param0: number): com.couchbase.lite.MutableArrayInterface;
 					addFloat(param0: number): com.couchbase.lite.MutableArrayInterface;
 					addDouble(param0: number): com.couchbase.lite.MutableArrayInterface;
 					addBoolean(param0: boolean): com.couchbase.lite.MutableArrayInterface;
-					addBlob(param0: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
+					addString(param0: string): com.couchbase.lite.MutableArrayInterface;
+					addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
 					addDate(param0: java.util.Date): com.couchbase.lite.MutableArrayInterface;
+					addBlob(param0: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 					addArray(param0: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
 					addDictionary(param0: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
-					insertValue(param0: number, param1: any): com.couchbase.lite.MutableArrayInterface;
-					insertString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
-					insertNumber(param0: number, param1: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+					addValue(param0: any): com.couchbase.lite.MutableArrayInterface;
 					insertInt(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					insertLong(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					insertFloat(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					insertDouble(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 					insertBoolean(param0: number, param1: boolean): com.couchbase.lite.MutableArrayInterface;
-					insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 					insertDate(param0: number, param1: java.util.Date): com.couchbase.lite.MutableArrayInterface;
+					insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
+					insertNumber(param0: number, param1: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+					insertString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 					insertArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
 					insertDictionary(param0: number, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
-					remove(param0: number): com.couchbase.lite.MutableArrayInterface;
-					getArray(param0: number): com.couchbase.lite.MutableArrayInterface;
-					getDictionary(param0: number): com.couchbase.lite.MutableDictionaryInterface;
+					insertValue(param0: number, param1: any): com.couchbase.lite.MutableArrayInterface;
 					getDictionary(param0: number): com.couchbase.lite.DictionaryInterface;
 					getArray(param0: number): com.couchbase.lite.ArrayInterface;
 					count(): number;
-					getValue(param0: number): any;
-					getString(param0: number): string;
-					getNumber(param0: number): java.lang.Number;
 					getInt(param0: number): number;
 					getLong(param0: number): number;
 					getFloat(param0: number): number;
 					getDouble(param0: number): number;
 					getBoolean(param0: number): boolean;
-					getBlob(param0: number): com.couchbase.lite.Blob;
+					getNumber(param0: number): java.lang.Number;
+					getString(param0: number): string;
 					getDate(param0: number): java.util.Date;
+					getBlob(param0: number): com.couchbase.lite.Blob;
 					getArray(param0: number): com.couchbase.lite.ArrayInterface;
 					getDictionary(param0: number): com.couchbase.lite.DictionaryInterface;
+					getValue(param0: number): any;
 					toList(): java.util.List<any>;
+					toJSON(): string;
 				});
 				public constructor();
 				public insertBoolean(param0: number, param1: boolean): com.couchbase.lite.MutableArrayInterface;
@@ -1997,18 +2117,19 @@ declare module com {
 				public addDictionary(param0: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
 				public getDictionary(param0: number): com.couchbase.lite.MutableDictionaryInterface;
 				public insertArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
+				public setJSON(param0: string): com.couchbase.lite.MutableArrayInterface;
 				public setDouble(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 				public insertDictionary(param0: number, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableArrayInterface;
 				public setArray(param0: number, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableArrayInterface;
 				public getInt(param0: number): number;
 				public setLong(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
-				public setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 				public setDate(param0: number, param1: java.util.Date): com.couchbase.lite.MutableArrayInterface;
+				public setString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 				public addInt(param0: number): com.couchbase.lite.MutableArrayInterface;
-				public insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 				public getArray(param0: number): com.couchbase.lite.MutableArrayInterface;
-				public addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
+				public insertBlob(param0: number, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 				public addBoolean(param0: boolean): com.couchbase.lite.MutableArrayInterface;
+				public addNumber(param0: java.lang.Number): com.couchbase.lite.MutableArrayInterface;
 				public insertFloat(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
 				public getDate(param0: number): java.util.Date;
 				public setInt(param0: number, param1: number): com.couchbase.lite.MutableArrayInterface;
@@ -2017,6 +2138,7 @@ declare module com {
 				public addBlob(param0: com.couchbase.lite.Blob): com.couchbase.lite.MutableArrayInterface;
 				public addDate(param0: java.util.Date): com.couchbase.lite.MutableArrayInterface;
 				public getArray(param0: number): com.couchbase.lite.ArrayInterface;
+				public toJSON(): string;
 				public getFloat(param0: number): number;
 				public insertString(param0: number, param1: string): com.couchbase.lite.MutableArrayInterface;
 				public getString(param0: number): string;
@@ -2080,15 +2202,18 @@ declare module com {
 				public getArray(param0: string): com.couchbase.lite.ArrayInterface;
 				public setInt(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 				public getDictionary(param0: string): com.couchbase.lite.MutableDictionary;
+				public toJSON(): string;
 				public isChanged(): boolean;
 				public getArray(param0: string): com.couchbase.lite.Array;
 				public getDictionary(param0: string): com.couchbase.lite.MutableDictionaryInterface;
+				public setJSON(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 				public setValue(param0: string, param1: any): com.couchbase.lite.MutableDictionary;
 				public getKeys(): java.util.List<string>;
+				public constructor(param0: string);
 				public setString(param0: string, param1: string): com.couchbase.lite.MutableDictionary;
 				public getValue(param0: string): any;
-				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getArray(param0: string): com.couchbase.lite.MutableArrayInterface;
+				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
 				public setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
 				public contains(param0: string): boolean;
@@ -2106,6 +2231,7 @@ declare module com {
 				public setDouble(param0: string, param1: number): com.couchbase.lite.MutableDictionary;
 				public getDouble(param0: string): number;
 				public getDate(param0: string): java.util.Date;
+				public setJSON(param0: string): com.couchbase.lite.MutableDictionary;
 				public count(): number;
 				public toMap(): java.util.Map<string,any>;
 				public setNumber(param0: string, param1: java.lang.Number): com.couchbase.lite.MutableDictionaryInterface;
@@ -2124,57 +2250,60 @@ declare module com {
 				 * Constructs a new instance of the com.couchbase.lite.MutableDictionaryInterface interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 				 */
 				public constructor(implementation: {
-					setData(param0: java.util.Map<string,any>): com.couchbase.lite.MutableDictionaryInterface;
-					setValue(param0: string, param1: any): com.couchbase.lite.MutableDictionaryInterface;
-					setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
-					setNumber(param0: string, param1: java.lang.Number): com.couchbase.lite.MutableDictionaryInterface;
+					getArray(param0: string): com.couchbase.lite.MutableArrayInterface;
+					getDictionary(param0: string): com.couchbase.lite.MutableDictionaryInterface;
+					remove(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 					setInt(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 					setLong(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 					setFloat(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 					setDouble(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 					setBoolean(param0: string, param1: boolean): com.couchbase.lite.MutableDictionaryInterface;
-					setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
+					setNumber(param0: string, param1: java.lang.Number): com.couchbase.lite.MutableDictionaryInterface;
+					setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
 					setDate(param0: string, param1: java.util.Date): com.couchbase.lite.MutableDictionaryInterface;
+					setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
+					setValue(param0: string, param1: any): com.couchbase.lite.MutableDictionaryInterface;
 					setArray(param0: string, param1: com.couchbase.lite.Array): com.couchbase.lite.MutableDictionaryInterface;
 					setDictionary(param0: string, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableDictionaryInterface;
-					remove(param0: string): com.couchbase.lite.MutableDictionaryInterface;
-					getArray(param0: string): com.couchbase.lite.MutableArrayInterface;
-					getDictionary(param0: string): com.couchbase.lite.MutableDictionaryInterface;
+					setData(param0: java.util.Map<string,any>): com.couchbase.lite.MutableDictionaryInterface;
+					setJSON(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 					getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
 					getArray(param0: string): com.couchbase.lite.ArrayInterface;
 					count(): number;
-					getKeys(): java.util.List<string>;
-					getValue(param0: string): any;
-					getString(param0: string): string;
-					getNumber(param0: string): java.lang.Number;
+					contains(param0: string): boolean;
 					getInt(param0: string): number;
 					getLong(param0: string): number;
 					getFloat(param0: string): number;
 					getDouble(param0: string): number;
 					getBoolean(param0: string): boolean;
-					getBlob(param0: string): com.couchbase.lite.Blob;
+					getNumber(param0: string): java.lang.Number;
+					getString(param0: string): string;
 					getDate(param0: string): java.util.Date;
+					getBlob(param0: string): com.couchbase.lite.Blob;
 					getArray(param0: string): com.couchbase.lite.ArrayInterface;
 					getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
+					getValue(param0: string): any;
+					getKeys(): java.util.List<string>;
 					toMap(): java.util.Map<string,any>;
-					contains(param0: string): boolean;
+					toJSON(): string;
 				});
 				public constructor();
 				public setDate(param0: string, param1: java.util.Date): com.couchbase.lite.MutableDictionaryInterface;
+				public setJSON(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 				public getKeys(): java.util.List<string>;
 				public getValue(param0: string): any;
-				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getArray(param0: string): com.couchbase.lite.MutableArrayInterface;
+				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
-				public setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
 				public remove(param0: string): com.couchbase.lite.MutableDictionaryInterface;
+				public setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
 				public getNumber(param0: string): java.lang.Number;
 				public contains(param0: string): boolean;
 				public setDictionary(param0: string, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableDictionaryInterface;
 				public getBoolean(param0: string): boolean;
 				public setDouble(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
-				public getString(param0: string): string;
 				public getFloat(param0: string): number;
+				public getString(param0: string): string;
 				public getBlob(param0: string): com.couchbase.lite.Blob;
 				public setLong(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 				public getLong(param0: string): number;
@@ -2188,6 +2317,7 @@ declare module com {
 				public getDate(param0: string): java.util.Date;
 				public setInt(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 				public count(): number;
+				public toJSON(): string;
 				public toMap(): java.util.Map<string,any>;
 				public setNumber(param0: string, param1: java.lang.Number): com.couchbase.lite.MutableDictionaryInterface;
 				public getInt(param0: string): number;
@@ -2225,29 +2355,33 @@ declare module com {
 				public constructor(param0: java.util.Map<string,any>);
 				public setValue(param0: string, param1: any): com.couchbase.lite.MutableDictionaryInterface;
 				public getArray(param0: string): com.couchbase.lite.ArrayInterface;
-				public constructor(param0: com.couchbase.lite.Database, param1: string, param2: com.couchbase.lite.internal.core.C4Document);
 				public setInt(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 				public getDictionary(param0: string): com.couchbase.lite.MutableDictionary;
+				public toJSON(): string;
 				public getArray(param0: string): com.couchbase.lite.Array;
 				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDocument;
 				public getDictionary(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 				public setDate(param0: string, param1: java.util.Date): com.couchbase.lite.MutableDocument;
+				public setJSON(param0: string): com.couchbase.lite.MutableDictionaryInterface;
 				public getKeys(): java.util.List<string>;
 				public constructor(param0: string);
 				public toMutable(): com.couchbase.lite.MutableDocument;
 				public remove(param0: string): com.couchbase.lite.MutableDocument;
 				public setDictionary(param0: string, param1: com.couchbase.lite.Dictionary): com.couchbase.lite.MutableDocument;
 				public getValue(param0: string): any;
-				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getArray(param0: string): com.couchbase.lite.MutableArrayInterface;
+				public setBlob(param0: string, param1: com.couchbase.lite.Blob): com.couchbase.lite.MutableDictionaryInterface;
 				public getDictionary(param0: string): com.couchbase.lite.DictionaryInterface;
 				public setString(param0: string, param1: string): com.couchbase.lite.MutableDictionaryInterface;
 				public contains(param0: string): boolean;
 				public setDouble(param0: string, param1: number): com.couchbase.lite.MutableDictionaryInterface;
 				public getString(param0: string): string;
 				public getBlob(param0: string): com.couchbase.lite.Blob;
+				public constructor(param0: string, param1: string);
 				public constructor(param0: string, param1: java.util.Map<string,any>);
+				public constructor(param0: com.couchbase.lite.Database, param1: string, param2: com.couchbase.lite.internal.core.C4Document, param3: boolean);
 				public setInt(param0: string, param1: number): com.couchbase.lite.MutableDocument;
+				public setJSON(param0: string): com.couchbase.lite.MutableDocument;
 				public setBoolean(param0: string, param1: boolean): com.couchbase.lite.MutableDictionaryInterface;
 				public setDouble(param0: string, param1: number): com.couchbase.lite.MutableDocument;
 				public constructor(param0: com.couchbase.lite.Document);
@@ -2267,8 +2401,18 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export abstract class NetworkReachabilityListener {
-				public static class: java.lang.Class<com.couchbase.lite.NetworkReachabilityListener>;
+			export class N1qlQuery extends com.couchbase.lite.AbstractQuery {
+				public static class: java.lang.Class<com.couchbase.lite.N1qlQuery>;
+				public getDatabase(): com.couchbase.lite.AbstractDatabase;
+				public execute(): com.couchbase.lite.ResultSet;
+				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
+				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
+				public getParameters(): com.couchbase.lite.Parameters;
+				public prepQueryLocked(param0: com.couchbase.lite.AbstractDatabase): com.couchbase.lite.internal.core.C4Query;
+				public setParameters(param0: com.couchbase.lite.Parameters): void;
+				public toString(): string;
+				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
+				public explain(): string;
 			}
 		}
 	}
@@ -2277,23 +2421,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class NetworkReachabilityManager extends com.couchbase.lite.AbstractNetworkReachabilityManager {
-				public static class: java.lang.Class<com.couchbase.lite.NetworkReachabilityManager>;
-			}
-			export module NetworkReachabilityManager {
-				export class NetworkReceiver {
-					public static class: java.lang.Class<com.couchbase.lite.NetworkReachabilityManager.NetworkReceiver>;
-					public onReceive(param0: globalAndroid.content.Context, param1: globalAndroid.content.Intent): void;
-				}
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export class OrderBy extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.LimitRouter {
+			export class OrderBy extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.OrderBy>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public limit(param0: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
@@ -2318,10 +2446,10 @@ declare module com {
 				 * Constructs a new instance of the com.couchbase.lite.OrderByRouter interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 				 */
 				public constructor(implementation: {
-					orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+					orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 				});
 				public constructor();
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 			}
 		}
 	}
@@ -2418,8 +2546,9 @@ declare module com {
 		export module lite {
 			export class QueryBuilder {
 				public static class: java.lang.Class<com.couchbase.lite.QueryBuilder>;
-				public static selectDistinct(param0: native.Array<com.couchbase.lite.SelectResult>): com.couchbase.lite.Select;
-				public static select(param0: native.Array<com.couchbase.lite.SelectResult>): com.couchbase.lite.Select;
+				public static select(param0: androidNative.Array<com.couchbase.lite.SelectResult>): com.couchbase.lite.Select;
+				public static selectDistinct(param0: androidNative.Array<com.couchbase.lite.SelectResult>): com.couchbase.lite.Select;
+				public static createQuery(param0: string, param1: com.couchbase.lite.Database): com.couchbase.lite.Query;
 			}
 		}
 	}
@@ -2464,7 +2593,7 @@ declare module com {
 		export module lite {
 			export class ReplicatedDocument {
 				public static class: java.lang.Class<com.couchbase.lite.ReplicatedDocument>;
-				public flags(): java.util.EnumSet<com.couchbase.lite.DocumentFlag>;
+				public getFlags(): java.util.EnumSet<com.couchbase.lite.DocumentFlag>;
 				public getError(): com.couchbase.lite.CouchbaseLiteException;
 				public toString(): string;
 				public getID(): string;
@@ -2496,9 +2625,27 @@ declare module com {
 		export module lite {
 			export class Replicator extends com.couchbase.lite.AbstractReplicator {
 				public static class: java.lang.Class<com.couchbase.lite.Replicator>;
-				public schema(): string;
+				public createReplicatorForTarget(param0: com.couchbase.lite.Endpoint): com.couchbase.lite.internal.core.C4Replicator;
+				public handleOffline(param0: com.couchbase.lite.ReplicatorActivityLevel, param1: boolean): void;
 				public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
-				public framing(): number;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ReplicatorActivityLevel {
+				public static class: java.lang.Class<com.couchbase.lite.ReplicatorActivityLevel>;
+				public static STOPPED: com.couchbase.lite.ReplicatorActivityLevel;
+				public static OFFLINE: com.couchbase.lite.ReplicatorActivityLevel;
+				public static CONNECTING: com.couchbase.lite.ReplicatorActivityLevel;
+				public static IDLE: com.couchbase.lite.ReplicatorActivityLevel;
+				public static BUSY: com.couchbase.lite.ReplicatorActivityLevel;
+				public static values(): androidNative.Array<com.couchbase.lite.ReplicatorActivityLevel>;
+				public static valueOf(param0: string): com.couchbase.lite.ReplicatorActivityLevel;
 			}
 		}
 	}
@@ -2509,7 +2656,7 @@ declare module com {
 		export module lite {
 			export class ReplicatorChange {
 				public static class: java.lang.Class<com.couchbase.lite.ReplicatorChange>;
-				public getStatus(): com.couchbase.lite.AbstractReplicator.Status;
+				public getStatus(): com.couchbase.lite.ReplicatorStatus;
 				public toString(): string;
 				public getReplicator(): com.couchbase.lite.Replicator;
 			}
@@ -2550,8 +2697,66 @@ declare module com {
 		export module lite {
 			export class ReplicatorConfiguration extends com.couchbase.lite.AbstractReplicatorConfiguration {
 				public static class: java.lang.Class<com.couchbase.lite.ReplicatorConfiguration>;
+				public constructor(param0: com.couchbase.lite.Database, param1: com.couchbase.lite.ReplicatorType, param2: boolean, param3: com.couchbase.lite.Authenticator, param4: java.util.Map<string,string>, param5: androidNative.Array<number>, param6: java.util.List<string>, param7: java.util.List<string>, param8: com.couchbase.lite.ReplicationFilter, param9: com.couchbase.lite.ReplicationFilter, param10: com.couchbase.lite.ConflictResolver, param11: number, param12: number, param13: number, param14: boolean, param15: com.couchbase.lite.Endpoint);
+				public constructor(param0: com.couchbase.lite.AbstractReplicatorConfiguration);
 				public constructor(param0: com.couchbase.lite.Database, param1: com.couchbase.lite.Endpoint);
 				public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
+				public getReplicatorConfiguration(): com.couchbase.lite.ReplicatorConfiguration;
+				public constructor(param0: com.couchbase.lite.internal.BaseImmutableReplicatorConfiguration);
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ReplicatorListener extends com.couchbase.lite.internal.core.C4ReplicatorListener {
+				public static class: java.lang.Class<com.couchbase.lite.ReplicatorListener>;
+				public statusChanged(param0: com.couchbase.lite.internal.core.C4Replicator, param1: com.couchbase.lite.internal.core.C4ReplicatorStatus, param2: any): void;
+				public documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: androidNative.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ReplicatorProgress {
+				public static class: java.lang.Class<com.couchbase.lite.ReplicatorProgress>;
+				public getCompleted(): number;
+				public getTotal(): number;
+				public toString(): string;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ReplicatorStatus {
+				public static class: java.lang.Class<com.couchbase.lite.ReplicatorStatus>;
+				public getActivityLevel(): com.couchbase.lite.ReplicatorActivityLevel;
+				public getProgress(): com.couchbase.lite.ReplicatorProgress;
+				public getError(): com.couchbase.lite.CouchbaseLiteException;
+				public toString(): string;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ReplicatorType {
+				public static class: java.lang.Class<com.couchbase.lite.ReplicatorType>;
+				public static PUSH_AND_PULL: com.couchbase.lite.ReplicatorType;
+				public static PUSH: com.couchbase.lite.ReplicatorType;
+				public static PULL: com.couchbase.lite.ReplicatorType;
+				public static valueOf(param0: string): com.couchbase.lite.ReplicatorType;
+				public static values(): androidNative.Array<com.couchbase.lite.ReplicatorType>;
 			}
 		}
 	}
@@ -2590,6 +2795,7 @@ declare module com {
 				public iterator(): java.util.Iterator<string>;
 				public getValue(param0: number): any;
 				public count(): number;
+				public toJSON(): string;
 				public getArray(param0: number): com.couchbase.lite.ArrayInterface;
 				public toMap(): java.util.Map<string,any>;
 				public getFloat(param0: number): number;
@@ -2604,19 +2810,10 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class ResultContext extends com.couchbase.lite.DocContext {
-				public static class: java.lang.Class<com.couchbase.lite.ResultContext>;
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export class ResultSet extends java.lang.Iterable<com.couchbase.lite.Result> {
+			export class ResultSet extends java.lang.Object {
 				public static class: java.lang.Class<com.couchbase.lite.ResultSet>;
 				public allResults(): java.util.List<com.couchbase.lite.Result>;
+				public close(): void;
 				public next(): com.couchbase.lite.Result;
 				public iterator(): java.util.Iterator<com.couchbase.lite.Result>;
 				public finalize(): void;
@@ -2628,7 +2825,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Select extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.FromRouter {
+			export class Select extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.FromRouter {
 				public static class: java.lang.Class<com.couchbase.lite.Select>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public addChangeListener(param0: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
@@ -2650,12 +2847,14 @@ declare module com {
 				public static class: java.lang.Class<com.couchbase.lite.SelectResult>;
 				public static property(param0: string): com.couchbase.lite.SelectResult.As;
 				public static all(): com.couchbase.lite.SelectResult.From;
+				public constructor(param0: com.couchbase.lite.Expression);
 				public static expression(param0: com.couchbase.lite.Expression): com.couchbase.lite.SelectResult.As;
+				public setExpression(param0: com.couchbase.lite.Expression): void;
 			}
 			export module SelectResult {
 				export class As extends com.couchbase.lite.SelectResult {
 					public static class: java.lang.Class<com.couchbase.lite.SelectResult.As>;
-					public as(param0: string): com.couchbase.lite.SelectResult;
+					public as(param0: string): com.couchbase.lite.SelectResult.As;
 				}
 				export class From extends com.couchbase.lite.SelectResult {
 					public static class: java.lang.Class<com.couchbase.lite.SelectResult.From>;
@@ -2697,8 +2896,39 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class ValueIndex extends com.couchbase.lite.AbstractIndex {
+			export class UnitOfWork<E>  extends java.lang.Object {
+				public static class: java.lang.Class<com.couchbase.lite.UnitOfWork<any>>;
+				/**
+				 * Constructs a new instance of the com.couchbase.lite.UnitOfWork<any> interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					run(): void;
+				});
+				public constructor();
+				public run(): void;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ValueIndex extends com.couchbase.lite.Index {
 				public static class: java.lang.Class<com.couchbase.lite.ValueIndex>;
+				public indexItems: java.util.List<com.couchbase.lite.ValueIndexItem>;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export class ValueIndexConfiguration extends com.couchbase.lite.IndexConfiguration {
+				public static class: java.lang.Class<com.couchbase.lite.ValueIndexConfiguration>;
+				public constructor(param0: com.couchbase.lite.AbstractIndex.IndexType, param1: com.couchbase.lite.AbstractIndex.QueryLanguage);
+				public constructor(param0: androidNative.Array<string>);
 			}
 		}
 	}
@@ -2729,7 +2959,7 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export class Where extends com.couchbase.lite.AbstractQuery implements com.couchbase.lite.GroupByRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
+			export class Where extends com.couchbase.lite.BuilderQuery implements com.couchbase.lite.GroupByRouter, com.couchbase.lite.OrderByRouter, com.couchbase.lite.LimitRouter {
 				public static class: java.lang.Class<com.couchbase.lite.Where>;
 				public execute(): com.couchbase.lite.ResultSet;
 				public limit(param0: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
@@ -2737,10 +2967,10 @@ declare module com {
 				public removeChangeListener(param0: com.couchbase.lite.ListenerToken): void;
 				public limit(param0: com.couchbase.lite.Expression, param1: com.couchbase.lite.Expression): com.couchbase.lite.Limit;
 				public getParameters(): com.couchbase.lite.Parameters;
+				public groupBy(param0: androidNative.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
 				public setParameters(param0: com.couchbase.lite.Parameters): void;
-				public orderBy(param0: native.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
+				public orderBy(param0: androidNative.Array<com.couchbase.lite.Ordering>): com.couchbase.lite.OrderBy;
 				public addChangeListener(param0: java.util.concurrent.Executor, param1: com.couchbase.lite.QueryChangeListener): com.couchbase.lite.ListenerToken;
-				public groupBy(param0: native.Array<com.couchbase.lite.Expression>): com.couchbase.lite.GroupBy;
 				public explain(): string;
 			}
 		}
@@ -2769,32 +2999,38 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export abstract class AbstractExecutionService extends com.couchbase.lite.internal.ExecutionService {
-					public static class: java.lang.Class<com.couchbase.lite.internal.AbstractExecutionService>;
-					public static MIN_CAPACITY: number;
-					public cancelDelayedTask(param0: com.couchbase.lite.internal.ExecutionService.Cancellable): void;
-					public constructor(param0: java.util.concurrent.ThreadPoolExecutor);
-					public getMainExecutor(): java.util.concurrent.Executor;
-					public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.ExecutionService.Cancellable;
-					public getConcurrentExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
-					public getSerialExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
+				export abstract class AbstractSocketFactory {
+					public static class: java.lang.Class<com.couchbase.lite.internal.AbstractSocketFactory>;
+					public endpoint: com.couchbase.lite.Endpoint;
+					public constructor(param0: com.couchbase.lite.ReplicatorConfiguration, param1: com.couchbase.lite.internal.replicator.CBLCookieStore, param2: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
+					public toString(): string;
+					public setListener(param0: com.couchbase.lite.internal.utils.Fn.Consumer<com.couchbase.lite.internal.core.C4Socket>): void;
+					public createSocket(param0: number, param1: string, param2: string, param3: number, param4: string, param5: androidNative.Array<number>): com.couchbase.lite.internal.core.C4Socket;
+					public createPlatformSocket(param0: number): com.couchbase.lite.internal.core.C4Socket;
 				}
-				export module AbstractExecutionService {
-					export class ConcurrentExecutor extends com.couchbase.lite.internal.ExecutionService.CloseableExecutor {
-						public static class: java.lang.Class<com.couchbase.lite.internal.AbstractExecutionService.ConcurrentExecutor>;
-						public execute(param0: java.lang.Runnable): void;
-						public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
-					}
-					export class InstrumentedTask {
-						public static class: java.lang.Class<com.couchbase.lite.internal.AbstractExecutionService.InstrumentedTask>;
-						public run(): void;
-						public setCompletion(param0: java.lang.Runnable): void;
-						public toString(): string;
-					}
-					export class SerialExecutor extends com.couchbase.lite.internal.ExecutionService.CloseableExecutor {
-						public static class: java.lang.Class<com.couchbase.lite.internal.AbstractExecutionService.SerialExecutor>;
-						public execute(param0: java.lang.Runnable): void;
-						public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export class AndroidExecutionService extends com.couchbase.lite.internal.exec.AbstractExecutionService {
+					public static class: java.lang.Class<com.couchbase.lite.internal.AndroidExecutionService>;
+					public getConcurrentExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+					public getSerialExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+					public constructor();
+					public constructor(param0: java.util.concurrent.ThreadPoolExecutor);
+					public cancelDelayedTask(param0: com.couchbase.lite.internal.exec.ExecutionService.Cancellable): void;
+					public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.exec.ExecutionService.Cancellable;
+					public getDefaultExecutor(): java.util.concurrent.Executor;
+				}
+				export module AndroidExecutionService {
+					export class CancellableTask extends com.couchbase.lite.internal.exec.ExecutionService.Cancellable {
+						public static class: java.lang.Class<com.couchbase.lite.internal.AndroidExecutionService.CancellableTask>;
+						public cancel(): void;
 					}
 				}
 			}
@@ -2806,21 +3042,42 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export class AndroidExecutionService extends com.couchbase.lite.internal.AbstractExecutionService {
-					public static class: java.lang.Class<com.couchbase.lite.internal.AndroidExecutionService>;
-					public cancelDelayedTask(param0: com.couchbase.lite.internal.ExecutionService.Cancellable): void;
-					public constructor();
-					public constructor(param0: java.util.concurrent.ThreadPoolExecutor);
-					public getMainExecutor(): java.util.concurrent.Executor;
-					public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.ExecutionService.Cancellable;
-					public getConcurrentExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
-					public getSerialExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
+				export class BaseImmutableDatabaseConfiguration {
+					public static class: java.lang.Class<com.couchbase.lite.internal.BaseImmutableDatabaseConfiguration>;
+					public getDirectory(): string;
+					public constructor(param0: com.couchbase.lite.DatabaseConfiguration);
 				}
-				export module AndroidExecutionService {
-					export class CancellableTask extends com.couchbase.lite.internal.ExecutionService.Cancellable {
-						public static class: java.lang.Class<com.couchbase.lite.internal.AndroidExecutionService.CancellableTask>;
-						public cancel(): void;
-					}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export class BaseImmutableReplicatorConfiguration {
+					public static class: java.lang.Class<com.couchbase.lite.internal.BaseImmutableReplicatorConfiguration>;
+					public getHeaders(): java.util.Map<string,string>;
+					public isPull(): boolean;
+					public getConflictResolver(): com.couchbase.lite.ConflictResolver;
+					public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
+					public getHeartbeat(): number;
+					public getPushFilter(): com.couchbase.lite.ReplicationFilter;
+					public getDatabase(): com.couchbase.lite.Database;
+					public getPullFilter(): com.couchbase.lite.ReplicationFilter;
+					public getMaxRetryAttemptWaitTime(): number;
+					public getTarget(): com.couchbase.lite.Endpoint;
+					public isPush(): boolean;
+					public isContinuous(): boolean;
+					public getChannels(): java.util.List<string>;
+					public getType(): com.couchbase.lite.ReplicatorType;
+					public getMaxRetryAttempts(): number;
+					public isAutoPurgeEnabled(): boolean;
+					public getAuthenticator(): com.couchbase.lite.Authenticator;
+					public getPinnedServerCertificate(): androidNative.Array<number>;
+					public getDocumentIDs(): java.util.List<string>;
+					public addConnectionOptions(param0: java.util.Map<string,any>): void;
 				}
 			}
 		}
@@ -2848,13 +3105,21 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export class CBLStatus {
-					public static class: java.lang.Class<com.couchbase.lite.internal.CBLStatus>;
-					public static convertError(param0: com.couchbase.lite.internal.core.C4Error): com.couchbase.lite.CouchbaseLiteException;
-					public static convertException(param0: com.couchbase.lite.LiteCoreException): com.couchbase.lite.CouchbaseLiteException;
-					public static convertException(param0: number, param1: number, param2: string, param3: java.lang.Exception): com.couchbase.lite.CouchbaseLiteException;
-					public static convertException(param0: com.couchbase.lite.LiteCoreException, param1: string): com.couchbase.lite.CouchbaseLiteException;
-					public static convertException(param0: number, param1: number, param2: number): com.couchbase.lite.CouchbaseLiteException;
+				export class CouchbaseLiteInternal {
+					public static class: java.lang.Class<com.couchbase.lite.internal.CouchbaseLiteInternal>;
+					public static SCRATCH_DIR_NAME: string;
+					public static getNetworkConnectivityManager(): com.couchbase.lite.internal.replicator.NetworkConnectivityManager;
+					public static getScratchDirPath(): string;
+					public static getExecutionService(): com.couchbase.lite.internal.exec.ExecutionService;
+					public static getScratchDir(): java.io.File;
+					public static getRootDirPath(): string;
+					public static reset(param0: boolean): void;
+					public static requireInit(param0: string): void;
+					public static getContext(): globalAndroid.content.Context;
+					public static getRootDir(): java.io.File;
+					public static debugging(): boolean;
+					public static init(param0: com.couchbase.lite.internal.fleece.MValue.Delegate, param1: boolean, param2: java.io.File, param3: java.io.File, param4: globalAndroid.content.Context): void;
+					public static loadErrorMessages(param0: globalAndroid.content.Context): java.util.Map<string,string>;
 				}
 			}
 		}
@@ -2865,56 +3130,71 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export class ExecutionService {
-					public static class: java.lang.Class<com.couchbase.lite.internal.ExecutionService>;
-					/**
-					 * Constructs a new instance of the com.couchbase.lite.internal.ExecutionService interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-					 */
-					public constructor(implementation: {
-						getMainExecutor(): java.util.concurrent.Executor;
-						getSerialExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
-						getConcurrentExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
-						postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.ExecutionService.Cancellable;
-						cancelDelayedTask(param0: com.couchbase.lite.internal.ExecutionService.Cancellable): void;
-					});
+				export class DbContext extends com.couchbase.lite.internal.fleece.MContext {
+					public static class: java.lang.Class<com.couchbase.lite.internal.DbContext>;
 					public constructor();
-					public cancelDelayedTask(param0: com.couchbase.lite.internal.ExecutionService.Cancellable): void;
-					public getMainExecutor(): java.util.concurrent.Executor;
-					public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.ExecutionService.Cancellable;
-					public getConcurrentExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
-					public getSerialExecutor(): com.couchbase.lite.internal.ExecutionService.CloseableExecutor;
+					public constructor(param0: com.couchbase.lite.BaseDatabase);
+					public getDatabase(): com.couchbase.lite.BaseDatabase;
 				}
-				export module ExecutionService {
-					export class Cancellable {
-						public static class: java.lang.Class<com.couchbase.lite.internal.ExecutionService.Cancellable>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.internal.ExecutionService$Cancellable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							cancel(): void;
-						});
-						public constructor();
-						public cancel(): void;
-					}
-					export class CloseableExecutor {
-						public static class: java.lang.Class<com.couchbase.lite.internal.ExecutionService.CloseableExecutor>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.internal.ExecutionService$CloseableExecutor interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
-						});
-						public constructor();
-						public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
-					}
-					export module CloseableExecutor {
-						export class ExecutorClosedException {
-							public static class: java.lang.Class<com.couchbase.lite.internal.ExecutionService.CloseableExecutor.ExecutorClosedException>;
-							public constructor();
-							public constructor(param0: string);
-							public constructor(param0: java.lang.Throwable);
-							public constructor(param0: string, param1: java.lang.Throwable);
-						}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export class ImmutableDatabaseConfiguration extends com.couchbase.lite.internal.BaseImmutableDatabaseConfiguration {
+					public static class: java.lang.Class<com.couchbase.lite.internal.ImmutableDatabaseConfiguration>;
+					public constructor(param0: com.couchbase.lite.DatabaseConfiguration);
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export class ImmutableReplicatorConfiguration extends com.couchbase.lite.internal.BaseImmutableReplicatorConfiguration {
+					public static class: java.lang.Class<com.couchbase.lite.internal.ImmutableReplicatorConfiguration>;
+					public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export class SocketFactory extends com.couchbase.lite.internal.AbstractSocketFactory {
+					public static class: java.lang.Class<com.couchbase.lite.internal.SocketFactory>;
+					public constructor(param0: com.couchbase.lite.ReplicatorConfiguration, param1: com.couchbase.lite.internal.replicator.CBLCookieStore, param2: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
+					public createPlatformSocket(param0: number): com.couchbase.lite.internal.core.C4Socket;
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module connectivity {
+					export class AndroidConnectivityManager extends com.couchbase.lite.internal.replicator.NetworkConnectivityManager {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.AndroidConnectivityManager>;
+						public unregisterObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+						public connectivityChanged(param0: boolean): void;
+						public static newInstance(): com.couchbase.lite.internal.connectivity.AndroidConnectivityManager;
+						public isConnected(): boolean;
+						public registerObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+						public constructor(param0: number, param1: com.couchbase.lite.internal.utils.Fn.Runner);
+						public isRunning(): boolean;
 					}
 				}
 			}
@@ -2926,10 +3206,102 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export class SocketFactory {
-					public static class: java.lang.Class<com.couchbase.lite.internal.SocketFactory>;
-					public constructor(param0: com.couchbase.lite.ReplicatorConfiguration);
-					public createSocket(param0: number, param1: string, param2: string, param3: number, param4: string, param5: native.Array<number>): com.couchbase.lite.internal.core.C4Socket;
+				export module connectivity {
+					export abstract class CallbackConnectivityWatcher extends com.couchbase.lite.internal.connectivity.ConnectivityWatcher {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.CallbackConnectivityWatcher>;
+						public connectivityCallback: globalAndroid.net.ConnectivityManager.NetworkCallback;
+						public stop(): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module connectivity {
+					export class ConnectivityListener21to23 extends com.couchbase.lite.internal.connectivity.CallbackConnectivityWatcher {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.ConnectivityListener21to23>;
+						public start(): void;
+						public isConnected(): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module connectivity {
+					export class ConnectivityListener24to28 extends com.couchbase.lite.internal.connectivity.CallbackConnectivityWatcher {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.ConnectivityListener24to28>;
+						public start(): void;
+						public isConnected(): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module connectivity {
+					export class ConnectivityListenerPost28 extends com.couchbase.lite.internal.connectivity.CallbackConnectivityWatcher {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.ConnectivityListenerPost28>;
+						public start(): void;
+						public isConnected(): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module connectivity {
+					export abstract class ConnectivityWatcher {
+						public static class: java.lang.Class<com.couchbase.lite.internal.connectivity.ConnectivityWatcher>;
+						public name: string;
+						public onConnectivityChange(param0: boolean): void;
+						public getSysMgr(): globalAndroid.net.ConnectivityManager;
+						public start(): void;
+						public logStart(): void;
+						public isConnected(): boolean;
+						public stop(): void;
+						public getCblMgr(): com.couchbase.lite.internal.connectivity.AndroidConnectivityManager;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module core {
+					export class BaseReplicator {
+						public static class: java.lang.Class<com.couchbase.lite.internal.core.BaseReplicator>;
+						public constructor();
+						public getC4Replicator(): com.couchbase.lite.internal.core.C4Replicator;
+						public close(): void;
+						public setC4Replicator(param0: com.couchbase.lite.internal.core.C4Replicator): void;
+						public getReplicatorLock(): any;
+						public finalize(): void;
+					}
 				}
 			}
 		}
@@ -2943,7 +3315,6 @@ declare module com {
 				export module core {
 					export class C4 {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4>;
-						public constructor();
 						public static setenv(param0: string, param1: string, param2: number): void;
 						public static getenv(param0: string): string;
 						public static getBuildInfo(): string;
@@ -2963,8 +3334,8 @@ declare module com {
 					export class C4Base {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Base>;
 						public static getMessage(param0: number, param1: number, param2: number): string;
-						public constructor();
 						public static setTempDir(param0: string): void;
+						public static debug(param0: boolean): void;
 					}
 				}
 			}
@@ -2977,9 +3348,11 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4BlobKey {
+					export class C4BlobKey extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobKey>;
-						public free(): void;
+						public constructor();
+						public close(): void;
+						public constructor(param0: number);
 						public toString(): string;
 						public constructor(param0: string);
 						public finalize(): void;
@@ -2995,13 +3368,13 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4BlobReadStream {
+					export class C4BlobReadStream extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobReadStream>;
 						public close(): void;
-						public read(param0: number): native.Array<number>;
+						public read(param0: androidNative.Array<number>, param1: number, param2: number): number;
 						public getLength(): number;
+						public read(param0: number): androidNative.Array<number>;
 						public seek(param0: number): void;
-						public read(param0: native.Array<number>, param1: number, param2: number): number;
 						public finalize(): void;
 					}
 				}
@@ -3015,19 +3388,30 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4BlobStore {
+					export abstract class C4BlobStore extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobStore>;
 						public openReadStream(param0: com.couchbase.lite.internal.core.C4BlobKey): com.couchbase.lite.internal.core.C4BlobReadStream;
 						public openWriteStream(): com.couchbase.lite.internal.core.C4BlobWriteStream;
-						public create(param0: native.Array<number>): com.couchbase.lite.internal.core.C4BlobKey;
 						public static open(param0: string, param1: number): com.couchbase.lite.internal.core.C4BlobStore;
-						public delete(): void;
 						public getSize(param0: com.couchbase.lite.internal.core.C4BlobKey): number;
-						public free(): void;
+						public create(param0: androidNative.Array<number>): com.couchbase.lite.internal.core.C4BlobKey;
+						public delete(): void;
+						public close(): void;
+						public static getUnmanagedBlobStore(param0: number): com.couchbase.lite.internal.core.C4BlobStore;
 						public getContents(param0: com.couchbase.lite.internal.core.C4BlobKey): com.couchbase.lite.internal.fleece.FLSliceResult;
 						public delete(param0: com.couchbase.lite.internal.core.C4BlobKey): void;
 						public getFilePath(param0: com.couchbase.lite.internal.core.C4BlobKey): string;
-						public finalize(): void;
+					}
+					export module C4BlobStore {
+						export class ManagedC4BlobStore extends com.couchbase.lite.internal.core.C4BlobStore {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobStore.ManagedC4BlobStore>;
+							public close(): void;
+							public finalize(): void;
+						}
+						export class UnmanagedC4BlobStore extends com.couchbase.lite.internal.core.C4BlobStore {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobStore.UnmanagedC4BlobStore>;
+							public close(): void;
+						}
 					}
 				}
 			}
@@ -3040,12 +3424,12 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4BlobWriteStream {
+					export class C4BlobWriteStream extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4BlobWriteStream>;
 						public close(): void;
-						public write(param0: native.Array<number>): void;
+						public write(param0: androidNative.Array<number>, param1: number): void;
 						public install(): void;
-						public write(param0: native.Array<number>, param1: number): void;
+						public write(param0: androidNative.Array<number>): void;
 						public computeBlobKey(): com.couchbase.lite.internal.core.C4BlobKey;
 						public finalize(): void;
 					}
@@ -3080,11 +3464,6 @@ declare module com {
 							public static HAS_ATTACHMENTS: number;
 							public static EXISTS: number;
 						}
-						export class DocumentVersioning {
-							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.DocumentVersioning>;
-							public static REVISION_TREES: number;
-							public static VERSION_VECTORS: number;
-						}
 						export class EncryptionAlgorithm {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.EncryptionAlgorithm>;
 							public static NONE: number;
@@ -3097,9 +3476,11 @@ declare module com {
 						export class EnumeratorFlags {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.EnumeratorFlags>;
 							public static DESCENDING: number;
+							public static UNSORTED: number;
 							public static INCLUDE_DELETED: number;
 							public static INCLUDE_NON_CONFLICTED: number;
 							public static INCLUDE_BODIES: number;
+							public static INCLUDE_REV_HISTORY: number;
 							public static DEFAULT: number;
 						}
 						export class ErrorDomain {
@@ -3110,16 +3491,37 @@ declare module com {
 							public static FLEECE: number;
 							public static NETWORK: number;
 							public static WEB_SOCKET: number;
+							public static MBED_TLS: number;
+							public static UNUSED: number;
 							public static MAX_ERROR_DOMAINS: number;
+						}
+						export class HttpError {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.HttpError>;
+							public static STATUS_MIN: number;
+							public static SWITCH_PROTOCOL: number;
+							public static MULTIPLE_CHOICE: number;
+							public static AUTH_REQUIRED: number;
+							public static FORBIDDEN: number;
+							public static NOT_FOUND: number;
+							public static CONFLICT: number;
+							public static PROXY_AUTH_REQUIRED: number;
+							public static ENTITY_TOO_LARGE: number;
+							public static IM_A_TEAPOT: number;
+							public static INTERNAL_SERVER_ERROR: number;
+							public static NOT_IMPLEMENTED: number;
+							public static SERVICE_UNAVAILABLE: number;
+							public static STATUS_MAX: number;
 						}
 						export class IndexType {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.IndexType>;
 							public static VALUE: number;
 							public static FULL_TEXT: number;
-							public static GEO: number;
+							public static ARRAY: number;
+							public static PREDICTIVE: number;
 						}
 						export class LiteCoreError {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.LiteCoreError>;
+							public static SUCCESS: number;
 							public static ASSERTION_FAILED: number;
 							public static UNIMPLEMENTED: number;
 							public static UNSUPPORTED_ENCRYPTION: number;
@@ -3150,16 +3552,23 @@ declare module com {
 							public static DATABASE_TOO_NEW: number;
 							public static BAD_DOC_ID: number;
 							public static CANT_UPGRADE_DATABASE: number;
+							public static DELTA_BASE_UNKNOWN: number;
+							public static CORRUPT_DELTA: number;
+							public static UNUSED: number;
 							public static MAX_ERROR_CODES: number;
 						}
 						export class LogDomain {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.LogDomain>;
 							public static DATABASE: string;
+							public static SQL: string;
+							public static ZIP: string;
 							public static QUERY: string;
-							public static SYNC: string;
 							public static WEB_SOCKET: string;
 							public static BLIP: string;
+							public static TLS: string;
+							public static SYNC: string;
 							public static SYNC_BUSY: string;
+							public static LISTENER: string;
 						}
 						export class LogLevel {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.LogLevel>;
@@ -3184,6 +3593,21 @@ declare module com {
 							public static TLS_CLIENT_CERT_REJECTED: number;
 							public static TLS_CERT_UNKNOWN_ROOT: number;
 							public static INVALID_REDIRECT: number;
+							public static UNKNOWN: number;
+							public static TLS_CERT_REVOKED: number;
+							public static TLS_CERT_NAME_MISMATCH: number;
+							public static NETWORK_RESET: number;
+							public static CONNECTION_ABORTED: number;
+							public static CONNECTION_RESET: number;
+							public static CONNECTION_REFUSED: number;
+							public static NETWORK_DOWN: number;
+							public static NETWORK_UNREACHABLE: number;
+							public static NOT_CONNECTED: number;
+							public static HOST_DOWN: number;
+							public static HOST_UNREACHABLE: number;
+							public static ADDRESS_NOT_AVAILABLE: number;
+							public static BROKEN_PIPE: number;
+							public static UNUSED: number;
 						}
 						export class RevisionFlags {
 							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.RevisionFlags>;
@@ -3195,6 +3619,24 @@ declare module com {
 							public static IS_CONFLICT: number;
 							public static CLOSED: number;
 							public static PURGED: number;
+						}
+						export class WebSocketError {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Constants.WebSocketError>;
+							public static NORMAL: number;
+							public static GOING_AWAY: number;
+							public static PROTOCOL_ERROR: number;
+							public static DATA_ERROR: number;
+							public static NO_CODE: number;
+							public static ABNORMAL_CLOSE: number;
+							public static BAD_MESSAGE_FORMAT: number;
+							public static POLICY_ERROR: number;
+							public static MESSAGE_TO_BIG: number;
+							public static MISSING_EXTENSION: number;
+							public static CANT_FULFILL: number;
+							public static TLS_FAILURE: number;
+							public static USER: number;
+							public static USER_TRANSIENT: number;
+							public static USER_PERMANENT: number;
 						}
 					}
 				}
@@ -3208,56 +3650,61 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4Database {
+					export abstract class C4Database extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Database>;
+						public static DB_EXTENSION: string;
 						public getSharedFleeceEncoder(): com.couchbase.lite.internal.fleece.FLEncoder;
-						public createReplicator(param0: string, param1: string, param2: number, param3: string, param4: string, param5: com.couchbase.lite.internal.core.C4Database, param6: number, param7: number, param8: native.Array<number>, param9: com.couchbase.lite.internal.core.C4ReplicatorListener, param10: com.couchbase.lite.internal.core.C4ReplicationFilter, param11: com.couchbase.lite.internal.core.C4ReplicationFilter, param12: com.couchbase.lite.AbstractReplicator, param13: com.couchbase.lite.internal.SocketFactory, param14: number): com.couchbase.lite.internal.core.C4Replicator;
-						public delete(): void;
+						public closeDb(): void;
 						public get(param0: string, param1: boolean): com.couchbase.lite.internal.core.C4Document;
-						public put(param0: com.couchbase.lite.internal.fleece.FLSliceResult, param1: string, param2: number, param3: boolean, param4: boolean, param5: native.Array<string>, param6: boolean, param7: number, param8: number): com.couchbase.lite.internal.core.C4Document;
-						public retain(): com.couchbase.lite.internal.core.C4Database;
 						public close(): void;
 						public getDocumentCount(): number;
-						public getPublicUUID(): native.Array<number>;
-						public purgeExpiredDocs(): number;
-						public getPath(): string;
-						public setMaxRevTreeDepth(param0: number): void;
+						public createN1qlQuery(param0: string): com.couchbase.lite.internal.core.C4Query;
+						public getPublicUUID(): androidNative.Array<number>;
+						public static getUnmanagedDatabase(param0: number): com.couchbase.lite.internal.core.C4Database;
 						public purgeDoc(param0: string): void;
 						public getBlobStore(): com.couchbase.lite.internal.core.C4BlobStore;
 						public endTransaction(param0: boolean): void;
-						public put(param0: native.Array<number>, param1: string, param2: number, param3: boolean, param4: boolean, param5: native.Array<string>, param6: boolean, param7: number, param8: number): com.couchbase.lite.internal.core.C4Document;
-						public finalize(): void;
-						public rawGet(param0: string, param1: string): com.couchbase.lite.internal.core.C4RawDocument;
+						public getDbName(): string;
+						public setCookie(param0: java.net.URI, param1: string): void;
+						public getDbDirectory(): string;
 						public beginTransaction(): void;
-						public free(): void;
-						public static rawFreeDocument(param0: number): void;
-						public createDatabaseObserver(param0: com.couchbase.lite.internal.core.C4DatabaseObserverListener, param1: any): com.couchbase.lite.internal.core.C4DatabaseObserver;
-						public createQuery(param0: string): com.couchbase.lite.internal.core.C4Query;
-						public getMaxRevTreeDepth(): number;
+						public performMaintenance(param0: com.couchbase.lite.MaintenanceType): boolean;
+						public createDocumentObserver(param0: string, param1: any, param2: com.couchbase.lite.internal.core.C4DocumentObserverListener): com.couchbase.lite.internal.core.C4DocumentObserver;
+						public createDatabaseObserver(param0: any, param1: com.couchbase.lite.internal.core.C4DatabaseObserverListener): com.couchbase.lite.internal.core.C4DatabaseObserver;
+						public createJsonQuery(param0: string): com.couchbase.lite.internal.core.C4Query;
+						public getDbFileName(): string;
 						public create(param0: string, param1: com.couchbase.lite.internal.fleece.FLSliceResult, param2: number): com.couchbase.lite.internal.core.C4Document;
-						public enumerateChanges(param0: number, param1: number): com.couchbase.lite.internal.core.C4DocEnumerator;
 						public deleteIndex(param0: string): void;
-						public getBySequence(param0: number): com.couchbase.lite.internal.core.C4Document;
-						public encodeJSON(param0: native.Array<number>): com.couchbase.lite.internal.fleece.FLSliceResult;
-						public enumerateAllDocs(param0: number): com.couchbase.lite.internal.core.C4DocEnumerator;
-						public nextDocExpiration(): number;
-						public rekey(param0: number, param1: native.Array<number>): void;
-						public getFLSharedKeys(): com.couchbase.lite.internal.fleece.FLSharedKeys;
-						public getIndexes(): com.couchbase.lite.internal.fleece.FLValue;
-						public createIndex(param0: string, param1: string, param2: number, param3: string, param4: boolean): boolean;
+						public deleteDb(): void;
+						public constructor();
+						public getIndexesInfo(): com.couchbase.lite.internal.fleece.FLValue;
+						public static getDatabase(param0: string, param1: string, param2: number, param3: number, param4: androidNative.Array<number>): com.couchbase.lite.internal.core.C4Database;
+						public createIndex(param0: string, param1: string, param2: com.couchbase.lite.AbstractIndex.QueryLanguage, param3: com.couchbase.lite.AbstractIndex.IndexType, param4: string, param5: boolean): void;
 						public getExpiration(param0: string): number;
-						public rawPut(param0: string, param1: string, param2: string, param3: native.Array<number>): void;
-						public createReplicator(param0: com.couchbase.lite.internal.core.C4Socket, param1: number, param2: number, param3: native.Array<number>, param4: com.couchbase.lite.internal.core.C4ReplicatorListener, param5: any): com.couchbase.lite.internal.core.C4Replicator;
-						public static copyDb(param0: string, param1: string, param2: number, param3: string, param4: number, param5: number, param6: native.Array<number>): void;
-						public getPrivateUUID(): native.Array<number>;
+						public createTargetReplicator(param0: com.couchbase.lite.internal.core.C4Socket, param1: number, param2: number, param3: androidNative.Array<number>, param4: com.couchbase.lite.internal.core.C4ReplicatorListener, param5: any): com.couchbase.lite.internal.core.C4Replicator;
+						public static copyDb(param0: string, param1: string, param2: string, param3: number, param4: number, param5: androidNative.Array<number>): void;
+						public createLocalReplicator(param0: com.couchbase.lite.internal.core.C4Database, param1: number, param2: number, param3: androidNative.Array<number>, param4: com.couchbase.lite.internal.core.C4ReplicatorListener, param5: com.couchbase.lite.internal.core.C4ReplicationFilter, param6: com.couchbase.lite.internal.core.C4ReplicationFilter, param7: com.couchbase.lite.AbstractReplicator): com.couchbase.lite.internal.core.C4Replicator;
 						public setExpiration(param0: string, param1: number): void;
-						public static deleteDbAtPath(param0: string): void;
+						public createRemoteReplicator(param0: string, param1: string, param2: number, param3: string, param4: string, param5: number, param6: number, param7: androidNative.Array<number>, param8: com.couchbase.lite.internal.core.C4ReplicatorListener, param9: com.couchbase.lite.internal.core.C4ReplicationFilter, param10: com.couchbase.lite.internal.core.C4ReplicationFilter, param11: com.couchbase.lite.AbstractReplicator, param12: com.couchbase.lite.internal.SocketFactory, param13: number): com.couchbase.lite.internal.core.C4Replicator;
+						public getCookies(param0: java.net.URI): string;
 						public constructor(param0: number);
-						public compact(): void;
-						public create(param0: string, param1: native.Array<number>, param2: number): com.couchbase.lite.internal.core.C4Document;
-						public constructor(param0: string, param1: number, param2: string, param3: number, param4: number, param5: native.Array<number>);
-						public getLastSequence(): number;
-						public createDocumentObserver(param0: string, param1: com.couchbase.lite.internal.core.C4DocumentObserverListener, param2: any): com.couchbase.lite.internal.core.C4DocumentObserver;
+						public getDbPath(): string;
+						public get(param0: string): com.couchbase.lite.internal.core.C4Document;
+						public static deleteNamedDb(param0: string, param1: string): void;
+						public put(param0: androidNative.Array<number>, param1: string, param2: number, param3: boolean, param4: boolean, param5: androidNative.Array<string>, param6: boolean, param7: number, param8: number): com.couchbase.lite.internal.core.C4Document;
+						public rekey(param0: number, param1: androidNative.Array<number>): void;
+						public static getDatabaseFile(param0: java.io.File, param1: string): java.io.File;
+					}
+					export module C4Database {
+						export class ManagedC4Database extends com.couchbase.lite.internal.core.C4Database {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Database.ManagedC4Database>;
+							public close(): void;
+							public finalize(): void;
+						}
+						export class UnmanagedC4Database extends com.couchbase.lite.internal.core.C4Database {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Database.UnmanagedC4Database>;
+							public close(): void;
+						}
 					}
 				}
 			}
@@ -3273,9 +3720,8 @@ declare module com {
 					export class C4DatabaseChange {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4DatabaseChange>;
 						public getSequence(): number;
-						public getBodySize(): number;
-						public constructor();
 						public isExternal(): boolean;
+						public static createC4DatabaseChange(param0: string, param1: string, param2: number, param3: boolean): com.couchbase.lite.internal.core.C4DatabaseChange;
 						public getRevID(): string;
 						public getDocID(): string;
 					}
@@ -3290,10 +3736,10 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4DatabaseObserver {
+					export class C4DatabaseObserver extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4DatabaseObserver>;
-						public getChanges(param0: number): native.Array<com.couchbase.lite.internal.core.C4DatabaseChange>;
-						public free(): void;
+						public close(): void;
+						public getChanges(param0: number): androidNative.Array<com.couchbase.lite.internal.core.C4DatabaseChange>;
 						public finalize(): void;
 					}
 				}
@@ -3329,10 +3775,9 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4DocEnumerator {
+					export class C4DocEnumerator extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4DocEnumerator>;
 						public close(): void;
-						public free(): void;
 						public getDocument(): com.couchbase.lite.internal.core.C4Document;
 						public next(): boolean;
 						public finalize(): void;
@@ -3348,39 +3793,29 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4Document extends com.couchbase.lite.internal.core.RefCounted {
+					export class C4Document extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Document>;
-						public selectNextRevision(): boolean;
-						public isSelectedRevFlags(param0: number): boolean;
-						public getSelectedRevID(): string;
-						public getSelectedBody(): native.Array<number>;
-						public selectFirstPossibleAncestorOf(param0: string): boolean;
-						public getSelectedFlags(): number;
-						public conflicted(): boolean;
-						public getSelectedBody2(): com.couchbase.lite.internal.fleece.FLDict;
-						public deleted(): boolean;
-						public getDocID(): string;
-						public hasRevisionBody(): boolean;
-						public finalize(): void;
-						public exists(): boolean;
-						public selectNextPossibleAncestorOf(param0: string): boolean;
-						public selectCurrentRevision(): boolean;
-						public getFlags(): number;
-						public save(param0: number): void;
-						public getRevID(): string;
-						public resolveConflict(param0: string, param1: string, param2: native.Array<number>, param3: number): void;
-						public bodyAsJSON(param0: boolean): string;
-						public loadRevisionBody(): void;
 						public getSequence(): number;
 						public selectNextLeafRevision(param0: boolean, param1: boolean): void;
 						public getSelectedSequence(): number;
 						public static dictContainsBlobs(param0: com.couchbase.lite.internal.fleece.FLSliceResult, param1: com.couchbase.lite.internal.fleece.FLSharedKeys): boolean;
-						public accessRemoved(): boolean;
+						public selectNextRevision(): boolean;
+						public isSelectedRevFlags(param0: number): boolean;
+						public close(): void;
+						public update(param0: androidNative.Array<number>, param1: number): com.couchbase.lite.internal.core.C4Document;
+						public resolveConflict(param0: string, param1: string, param2: androidNative.Array<number>, param3: number): void;
+						public getSelectedRevID(): string;
+						public getSelectedFlags(): number;
+						public getSelectedBody2(): com.couchbase.lite.internal.fleece.FLDict;
+						public deleted(): boolean;
+						public getDocID(): string;
 						public update(param0: com.couchbase.lite.internal.fleece.FLSliceResult, param1: number): com.couchbase.lite.internal.core.C4Document;
-						public update(param0: native.Array<number>, param1: number): com.couchbase.lite.internal.core.C4Document;
-						public purgeRevision(param0: string): number;
-						public selectCommonAncestorRevision(param0: string, param1: string): boolean;
-						public selectParentRevision(): boolean;
+						public finalize(): void;
+						public exists(): boolean;
+						public getFlags(): number;
+						public save(param0: number): void;
+						public getRevID(): string;
+						public bodyAsJSON(param0: boolean): string;
 					}
 				}
 			}
@@ -3395,8 +3830,9 @@ declare module com {
 				export module core {
 					export class C4DocumentEnded {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4DocumentEnded>;
-						public constructor();
+						public getSequence(): number;
 						public getErrorDomain(): number;
+						public constructor(param0: string, param1: string, param2: number, param3: number, param4: number, param5: number, param6: number, param7: boolean);
 						public getErrorCode(): number;
 						public errorIsTransient(): boolean;
 						public isConflicted(): boolean;
@@ -3418,9 +3854,9 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4DocumentObserver {
+					export class C4DocumentObserver extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4DocumentObserver>;
-						public free(): void;
+						public close(): void;
 						public finalize(): void;
 					}
 				}
@@ -3476,12 +3912,13 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4FullTextMatch {
+					export class C4FullTextMatch extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4FullTextMatch>;
 						public term(): number;
 						public start(): number;
 						public length(): number;
 						public property(): number;
+						public close(): void;
 						public dataSource(): number;
 						public toList(): java.util.List<java.lang.Long>;
 					}
@@ -3498,9 +3935,8 @@ declare module com {
 				export module core {
 					export class C4Key {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Key>;
-						public static getPbkdf2Key(param0: string): native.Array<number>;
-						public constructor();
-						public static getCoreKey(param0: string): native.Array<number>;
+						public static getPbkdf2Key(param0: string): androidNative.Array<number>;
+						public static getCoreKey(param0: string): androidNative.Array<number>;
 					}
 				}
 			}
@@ -3515,12 +3951,51 @@ declare module com {
 				export module core {
 					export class C4Log {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Log>;
-						public static setLevel(param0: string, param1: number): void;
+						public static forceCallbackLevel(param0: com.couchbase.lite.LogLevel): void;
+						public static getCallbackLevel(): com.couchbase.lite.LogLevel;
+						public static setLevels(param0: number, param1: androidNative.Array<string>): void;
+						public static logCallback(param0: string, param1: number, param2: string): void;
 						public static getBinaryFileLevel(): number;
 						public static log(param0: string, param1: number, param2: string): void;
 						public static setCallbackLevel(param0: com.couchbase.lite.LogLevel): void;
+						public static registerListener(param0: com.couchbase.lite.internal.utils.Fn.Consumer<com.couchbase.lite.internal.core.C4Log.RawLog>): void;
+						public static getLevel(param0: string): number;
 						public static writeToBinaryFile(param0: string, param1: number, param2: number, param3: number, param4: boolean, param5: string): void;
 						public static setBinaryFileLevel(param0: number): void;
+					}
+					export module C4Log {
+						export class RawLog {
+							public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Log.RawLog>;
+							public domain: string;
+							public level: number;
+							public message: string;
+							public toString(): string;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module core {
+					export abstract class C4NativePeer {
+						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4NativePeer>;
+						public releasePeer(): void;
+						public getPeer(): number;
+						public constructor();
+						public getPeerLock(): any;
+						public constructor(param0: number);
+						public releasePeer(param0: com.couchbase.lite.LogDomain, param1: com.couchbase.lite.internal.utils.Fn.ConsumerThrows<any,any>): void;
+						public withPeer(param0: any, param1: com.couchbase.lite.internal.utils.Fn.FunctionThrows<any,any,any>): any;
+						public getPeerUnchecked(): number;
+						public toString(): string;
+						public setPeer(param0: number): void;
+						public withPeerOrNull(param0: com.couchbase.lite.internal.utils.Fn.FunctionThrows<any,any,any>): any;
 					}
 				}
 			}
@@ -3535,7 +4010,6 @@ declare module com {
 				export module core {
 					export class C4Prediction {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Prediction>;
-						public constructor();
 						public static unregister(param0: string): void;
 						public static register(param0: string, param1: com.couchbase.lite.internal.core.C4PredictiveModel): void;
 					}
@@ -3572,13 +4046,17 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4Query {
+					export class C4Query extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Query>;
-						public getFullTextMatched(param0: com.couchbase.lite.internal.core.C4FullTextMatch): native.Array<number>;
-						public run(param0: com.couchbase.lite.internal.core.C4QueryOptions, param1: com.couchbase.lite.internal.fleece.AllocSlice): com.couchbase.lite.internal.core.C4QueryEnumerator;
-						public free(): void;
-						public columnCount(): number;
+						public getColumnNameForIndex(param0: number): string;
+						public close(): void;
+						public static deleteIndex(param0: com.couchbase.lite.internal.core.C4Database, param1: string): void;
+						public static getIndexInfo(param0: com.couchbase.lite.internal.core.C4Database): com.couchbase.lite.internal.fleece.FLValue;
+						public getFullTextMatched(param0: com.couchbase.lite.internal.core.C4FullTextMatch): androidNative.Array<number>;
+						public static createIndex(param0: com.couchbase.lite.internal.core.C4Database, param1: string, param2: string, param3: com.couchbase.lite.AbstractIndex.QueryLanguage, param4: com.couchbase.lite.AbstractIndex.IndexType, param5: string, param6: boolean): void;
+						public run(param0: com.couchbase.lite.internal.core.C4QueryOptions, param1: com.couchbase.lite.internal.fleece.FLSliceResult): com.couchbase.lite.internal.core.C4QueryEnumerator;
 						public explain(): string;
+						public getColumnCount(): number;
 						public finalize(): void;
 					}
 				}
@@ -3592,16 +4070,14 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4QueryEnumerator {
+					export class C4QueryEnumerator extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4QueryEnumerator>;
 						public getMissingColumns(): number;
-						public getFullTextMatchs(param0: number): com.couchbase.lite.internal.core.C4FullTextMatch;
-						public getFullTextMatchCount(): number;
 						public seek(param0: number): boolean;
-						public close(): void;
 						public getColumns(): com.couchbase.lite.internal.fleece.FLArrayIterator;
+						public close(): void;
 						public refresh(): com.couchbase.lite.internal.core.C4QueryEnumerator;
-						public free(): void;
+						public copy(): com.couchbase.lite.internal.core.C4QueryEnumerator;
 						public getRowCount(): number;
 						public next(): boolean;
 						public finalize(): void;
@@ -3634,11 +4110,11 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4RawDocument {
+					export class C4RawDocument extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4RawDocument>;
-						public body(): native.Array<number>;
-						public free(): void;
+						public close(): void;
 						public meta(): string;
+						public body(): androidNative.Array<number>;
 						public key(): string;
 						public finalize(): void;
 					}
@@ -3659,10 +4135,10 @@ declare module com {
 						 * Constructs a new instance of the com.couchbase.lite.internal.core.C4ReplicationFilter interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 						 */
 						public constructor(implementation: {
-							validationFunction(param0: string, param1: string, param2: number, param3: number, param4: boolean, param5: any): boolean;
+							validationFunction(param0: string, param1: string, param2: number, param3: number, param4: boolean, param5: com.couchbase.lite.AbstractReplicator): boolean;
 						});
 						public constructor();
-						public validationFunction(param0: string, param1: string, param2: number, param3: number, param4: boolean, param5: any): boolean;
+						public validationFunction(param0: string, param1: string, param2: number, param3: number, param4: boolean, param5: com.couchbase.lite.AbstractReplicator): boolean;
 					}
 				}
 			}
@@ -3675,19 +4151,60 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export class C4Replicator {
+					export class C4Replicator extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Replicator>;
+						public static WEBSOCKET_SCHEME: string;
+						public static WEBSOCKET_SECURE_CONNECTION_SCHEME: string;
+						public static MESSAGE_SCHEME: string;
 						public static C4_REPLICATOR_SCHEME_2: string;
 						public static C4_REPLICATOR_TLS_SCHEME_2: string;
-						public isDocumentPending(param0: string): java.lang.Boolean;
-						public static mayBeTransient(param0: com.couchbase.lite.internal.core.C4Error): boolean;
-						public start(): void;
+						public static REPLICATOR_OPTION_DOC_IDS: string;
+						public static REPLICATOR_OPTION_CHANNELS: string;
+						public static REPLICATOR_OPTION_FILTER: string;
+						public static REPLICATOR_OPTION_FILTER_PARAMS: string;
+						public static REPLICATOR_OPTION_SKIP_DELETED: string;
+						public static REPLICATOR_OPTION_NO_INCOMING_CONFLICTS: string;
+						public static REPLICATOR_OPTION_OUTGOING_CONFLICTS: string;
+						public static REPLICATOR_CHECKPOINT_INTERVAL: string;
+						public static REPLICATOR_OPTION_REMOTE_DB_UNIQUE_ID: string;
+						public static REPLICATOR_OPTION_PROGRESS_LEVEL: string;
+						public static REPLICATOR_OPTION_DISABLE_DELTAS: string;
+						public static REPLICATOR_OPTION_MAX_RETRIES: string;
+						public static REPLICATOR_OPTION_MAX_RETRY_INTERVAL: string;
+						public static REPLICATOR_OPTION_ENABLE_AUTO_PURGE: string;
+						public static REPLICATOR_OPTION_ROOT_CERTS: string;
+						public static REPLICATOR_OPTION_PINNED_SERVER_CERT: string;
+						public static REPLICATOR_OPTION_SELF_SIGNED_SERVER_CERT: string;
+						public static REPLICATOR_OPTION_EXTRA_HEADERS: string;
+						public static REPLICATOR_OPTION_COOKIES: string;
+						public static REPLICATOR_OPTION_AUTHENTICATION: string;
+						public static REPLICATOR_OPTION_PROXY_SERVER: string;
+						public static REPLICATOR_HEARTBEAT_INTERVAL: string;
+						public static SOCKET_OPTION_WS_PROTOCOLS: string;
+						public static REPLICATOR_AUTH_TYPE: string;
+						public static REPLICATOR_AUTH_USER_NAME: string;
+						public static REPLICATOR_AUTH_PASSWORD: string;
+						public static REPLICATOR_AUTH_CLIENT_CERT: string;
+						public static REPLICATOR_AUTH_CLIENT_CERT_KEY: string;
+						public static REPLICATOR_AUTH_TOKEN: string;
+						public static AUTH_TYPE_BASIC: string;
+						public static AUTH_TYPE_SESSION: string;
+						public static AUTH_TYPE_OPEN_ID_CONNECT: string;
+						public static AUTH_TYPE_FACEBOOK: string;
+						public static AUTH_TYPE_CLIENT_CERT: string;
+						public static PROGRESS_OVERALL: number;
+						public static PROGRESS_PER_DOC: number;
+						public static PROGRESS_PER_ATTACHMENT: number;
 						public getPendingDocIDs(): java.util.Set<string>;
+						public close(): void;
+						public setHostReachable(param0: boolean): void;
+						public start(param0: boolean): void;
 						public getStatus(): com.couchbase.lite.internal.core.C4ReplicatorStatus;
-						public free(): void;
-						public getResponseHeaders(): native.Array<number>;
+						public setOptions(param0: androidNative.Array<number>): void;
+						public isDocumentPending(param0: string): boolean;
+						public setProgressLevel(param0: number): void;
 						public stop(): void;
-						public static mayBeNetworkDependent(param0: com.couchbase.lite.internal.core.C4Error): boolean;
+						public toString(): string;
 						public finalize(): void;
 					}
 				}
@@ -3708,11 +4225,11 @@ declare module com {
 						 */
 						public constructor(implementation: {
 							statusChanged(param0: com.couchbase.lite.internal.core.C4Replicator, param1: com.couchbase.lite.internal.core.C4ReplicatorStatus, param2: any): void;
-							documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: native.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
+							documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: androidNative.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
 						});
 						public constructor();
 						public statusChanged(param0: com.couchbase.lite.internal.core.C4Replicator, param1: com.couchbase.lite.internal.core.C4ReplicatorStatus, param2: any): void;
-						public documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: native.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
+						public documentEnded(param0: com.couchbase.lite.internal.core.C4Replicator, param1: boolean, param2: androidNative.Array<com.couchbase.lite.internal.core.C4DocumentEnded>, param3: any): void;
 					}
 				}
 			}
@@ -3727,16 +4244,13 @@ declare module com {
 				export module core {
 					export class C4ReplicatorMode {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4ReplicatorMode>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.internal.core.C4ReplicatorMode interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-						});
-						public constructor();
-						public static C4_DISABLED: number;
-						public static C4_PASSIVE: number;
-						public static C4_ONE_SHOT: number;
-						public static C4_CONTINUOUS: number;
+						public static C4_DISABLED: com.couchbase.lite.internal.core.C4ReplicatorMode;
+						public static C4_PASSIVE: com.couchbase.lite.internal.core.C4ReplicatorMode;
+						public static C4_ONE_SHOT: com.couchbase.lite.internal.core.C4ReplicatorMode;
+						public static C4_CONTINUOUS: com.couchbase.lite.internal.core.C4ReplicatorMode;
+						public static values(): androidNative.Array<com.couchbase.lite.internal.core.C4ReplicatorMode>;
+						public static valueOf(param0: string): com.couchbase.lite.internal.core.C4ReplicatorMode;
+						public getVal(): number;
 					}
 				}
 			}
@@ -3751,21 +4265,18 @@ declare module com {
 				export module core {
 					export class C4ReplicatorStatus {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4ReplicatorStatus>;
+						public getProgressUnitsTotal(): number;
 						public getProgressDocumentCount(): number;
-						public constructor();
+						public getErrorDomain(): number;
 						public getErrorCode(): number;
 						public constructor(param0: number, param1: number, param2: number, param3: number, param4: number, param5: number, param6: number);
 						public copy(): com.couchbase.lite.internal.core.C4ReplicatorStatus;
-						public getC4Error(): com.couchbase.lite.internal.core.C4Error;
-						public getProgressUnitsCompleted(): number;
-						public toString(): string;
-						public getProgressUnitsTotal(): number;
-						public getErrorDomain(): number;
-						public copyAtlevel(param0: number): com.couchbase.lite.internal.core.C4ReplicatorStatus;
-						public constructor(param0: number);
 						public getActivityLevel(): number;
 						public getErrorInternalInfo(): number;
+						public getC4Error(): com.couchbase.lite.internal.core.C4Error;
 						public constructor(param0: number, param1: number, param2: number);
+						public getProgressUnitsCompleted(): number;
+						public toString(): string;
 					}
 					export module C4ReplicatorStatus {
 						export class ActivityLevel {
@@ -3788,91 +4299,26 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export abstract class C4Socket {
+					export abstract class C4Socket extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4Socket>;
-						public static WEBSOCKET_SCHEME: string;
-						public static WEBSOCKET_SECURE_CONNECTION_SCHEME: string;
-						public static REPLICATOR_OPTION_EXTRA_HEADERS: string;
-						public static REPLICATOR_OPTION_COOKIES: string;
-						public static REPLICATOR_OPTION_AUTHENTICATION: string;
-						public static REPLICATOR_OPTION_PINNED_SERVER_CERT: string;
-						public static REPLICATOR_OPTION_DOC_IDS: string;
-						public static REPLICATOR_OPTION_CHANNELS: string;
-						public static REPLICATOR_OPTION_FILTER: string;
-						public static REPLICATOR_OPTION_FILTER_PARAMS: string;
-						public static REPLICATOR_OPTION_SKIP_DELETED: string;
-						public static REPLICATOR_OPTION_NO_INCOMING_CONFLICTS: string;
-						public static REPLICATOR_OPTION_OUTGOING_CONFLICTS: string;
-						public static REPLICATOR_CHECKPOINT_INTERVAL: string;
-						public static REPLICATOR_OPTION_REMOTE_DB_UNIQUE_ID: string;
-						public static REPLICATOR_HEARTBEAT_INTERVAL: string;
-						public static REPLICATOR_RESET_CHECKPOINT: string;
-						public static REPLICATOR_OPTION_PROGRESS_LEVEL: string;
-						public static REPLICATOR_OPTION_DISABLE_DELTAS: string;
-						public static REPLICATOR_AUTH_TYPE: string;
-						public static REPLICATOR_AUTH_USER_NAME: string;
-						public static REPLICATOR_AUTH_PASSWORD: string;
-						public static REPLICATOR_AUTH_CLIENT_CERT: string;
-						public static AUTH_TYPE_BASIC: string;
-						public static AUTH_TYPE_SESSION: string;
-						public static AUTH_TYPE_OPEN_ID_CONNECT: string;
-						public static AUTH_TYPE_FACEBOOK: string;
-						public static AUTH_TYPE_CLIENT_CERT: string;
-						public static SOCKET_OPTION_WS_PROTOCOLS: string;
-						public static SOCKET_OPTION_HEARTBEAT: string;
-						public static REPLICATOR_OPTION_NO_CONFLICTS: string;
 						public static WEB_SOCKET_CLIENT_FRAMING: number;
 						public static NO_FRAMING: number;
 						public static WEB_SOCKET_SERVER_FRAMING: number;
-						public close(): void;
-						public received(param0: native.Array<number>): void;
+						public constructor();
+						public send(param0: androidNative.Array<number>): void;
+						public gotHTTPResponse(param0: number, param1: androidNative.Array<number>): void;
 						public opened(): void;
 						public constructor(param0: string, param1: string, param2: number, param3: string, param4: number);
-						public gotHTTPResponse(param0: number, param1: native.Array<number>): void;
 						public closeRequested(param0: number, param1: string): void;
 						public requestClose(param0: number, param1: string): void;
 						public completedWrite(param0: number): void;
+						public received(param0: androidNative.Array<number>): void;
 						public closed(param0: number, param1: number, param2: string): void;
 						public constructor(param0: number);
 						public openSocket(): void;
+						public closeSocket(): void;
 						public completedReceive(param0: number): void;
-						public released(): boolean;
-						public send(param0: native.Array<number>): void;
-					}
-				}
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export module internal {
-				export module core {
-					export class C4WebSocketCloseCode {
-						public static class: java.lang.Class<com.couchbase.lite.internal.core.C4WebSocketCloseCode>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.internal.core.C4WebSocketCloseCode interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-						});
-						public constructor();
-						public static kWebSocketCloseBadMessageFormat: number;
-						public static kWebSocketCloseUserPermanent: number;
-						public static kWebSocketCloseNoCode: number;
-						public static kWebSocketCloseAbnormal: number;
-						public static kWebSocketCloseMissingExtension: number;
-						public static kWebSocketCloseTLSFailure: number;
-						public static kWebSocketCloseGoingAway: number;
-						public static kWebSocketCloseNormal: number;
-						public static kWebSocketClosePolicyError: number;
-						public static kWebSocketCloseFirstAvailable: number;
-						public static kWebSocketCloseCantFulfill: number;
-						public static kWebSocketCloseProtocolError: number;
-						public static kWebSocketCloseUserTransient: number;
-						public static kWebSocketCloseDataError: number;
-						public static kWebSocketCloseMessageTooBig: number;
+						public isC4SocketClosing(): boolean;
 					}
 				}
 			}
@@ -3887,7 +4333,6 @@ declare module com {
 				export module core {
 					export class CBLVersion {
 						public static class: java.lang.Class<com.couchbase.lite.internal.core.CBLVersion>;
-						public constructor();
 						public static getSysInfo(): string;
 						public static getVersionInfo(): string;
 						public static getLibInfo(): string;
@@ -3904,10 +4349,13 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module core {
-					export abstract class RefCounted {
-						public static class: java.lang.Class<com.couchbase.lite.internal.core.RefCounted>;
-						public retain(): void;
-						public release(): void;
+					export class NativeContext<T>  extends java.lang.Object {
+						public static class: java.lang.Class<com.couchbase.lite.internal.core.NativeContext<any>>;
+						public getObjFromContext(param0: number): T;
+						public constructor();
+						public reserveKey(): number;
+						public bind(param0: number, param1: T): void;
+						public unbind(param0: number): void;
 					}
 				}
 			}
@@ -3936,23 +4384,173 @@ declare module com {
 	export module couchbase {
 		export module lite {
 			export module internal {
-				export module fleece {
-					export class AllocSlice {
-						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.AllocSlice>;
+				export module exec {
+					export abstract class AbstractExecutionService extends com.couchbase.lite.internal.exec.ExecutionService {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.AbstractExecutionService>;
+						public constructor(param0: java.util.concurrent.ThreadPoolExecutor);
+						public dumpState(): void;
+						public getConcurrentExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+						public static throttled(): boolean;
+						public getSerialExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+						public getDefaultExecutor(): java.util.concurrent.Executor;
+						public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.exec.ExecutionService.Cancellable;
+						public static dumpThreads(): void;
+						public cancelDelayedTask(param0: com.couchbase.lite.internal.exec.ExecutionService.Cancellable): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class CBLExecutor {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.CBLExecutor>;
+						public dumpState(): void;
+						public execute(param0: java.lang.Runnable): void;
+						public constructor(param0: string, param1: number, param2: number, param3: java.util.concurrent.BlockingQueue<java.lang.Runnable>);
+						public toString(): string;
+						public constructor(param0: string);
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class ClientTask<T>  extends java.lang.Object {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.ClientTask<any>>;
+						public constructor(param0: java.util.concurrent.Callable<T>);
+						public execute(param0: number, param1: java.util.concurrent.TimeUnit): void;
+						public execute(): void;
+						public getFailure(): java.lang.Exception;
+						public static dumpState(): void;
+						public getResult(): T;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class ConcurrentExecutor extends com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.ConcurrentExecutor>;
+						public execute(param0: java.lang.Runnable): void;
+						public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+						public dumpState(param0: com.couchbase.lite.internal.exec.InstrumentedTask): void;
+						public toString(): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class ExecutionService {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.ExecutionService>;
 						/**
-						 * Constructs a new instance of the com.couchbase.lite.internal.fleece.AllocSlice interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 * Constructs a new instance of the com.couchbase.lite.internal.exec.ExecutionService interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 						 */
 						public constructor(implementation: {
-							getHandle(): number;
-							getBuf(): native.Array<number>;
-							getSize(): number;
-							free(): void;
+							getDefaultExecutor(): java.util.concurrent.Executor;
+							getSerialExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+							getConcurrentExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+							postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.exec.ExecutionService.Cancellable;
+							cancelDelayedTask(param0: com.couchbase.lite.internal.exec.ExecutionService.Cancellable): void;
 						});
 						public constructor();
-						public getSize(): number;
-						public free(): void;
-						public getBuf(): native.Array<number>;
-						public getHandle(): number;
+						public getConcurrentExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+						public getSerialExecutor(): com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor;
+						public getDefaultExecutor(): java.util.concurrent.Executor;
+						public postDelayedOnExecutor(param0: number, param1: java.util.concurrent.Executor, param2: java.lang.Runnable): com.couchbase.lite.internal.exec.ExecutionService.Cancellable;
+						public cancelDelayedTask(param0: com.couchbase.lite.internal.exec.ExecutionService.Cancellable): void;
+					}
+					export module ExecutionService {
+						export class Cancellable {
+							public static class: java.lang.Class<com.couchbase.lite.internal.exec.ExecutionService.Cancellable>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.exec.ExecutionService$Cancellable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								cancel(): void;
+							});
+							public constructor();
+							public cancel(): void;
+						}
+						export class CloseableExecutor {
+							public static class: java.lang.Class<com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.exec.ExecutionService$CloseableExecutor interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+							});
+							public constructor();
+							public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+						}
+						export module CloseableExecutor {
+							export class ExecutorClosedException {
+								public static class: java.lang.Class<com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor.ExecutorClosedException>;
+								public constructor(param0: java.lang.Throwable);
+								public constructor(param0: string, param1: java.lang.Throwable);
+								public constructor();
+								public constructor(param0: string);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class InstrumentedTask {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.InstrumentedTask>;
+						public run(): void;
+						public constructor(param0: java.lang.Runnable, param1: java.lang.Runnable);
+						public toString(): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module exec {
+					export class SerialExecutor extends com.couchbase.lite.internal.exec.ExecutionService.CloseableExecutor {
+						public static class: java.lang.Class<com.couchbase.lite.internal.exec.SerialExecutor>;
+						public execute(param0: java.lang.Runnable): void;
+						public stop(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+						public dumpState(param0: com.couchbase.lite.internal.exec.InstrumentedTask): void;
+						public toString(): string;
 					}
 				}
 			}
@@ -3992,7 +4590,7 @@ declare module com {
 						public count(): number;
 						public get(param0: number): com.couchbase.lite.internal.fleece.FLValue;
 						public constructor(param0: number);
-						public asTypedArray(): java.util.List;
+						public asTypedArray(): java.util.List<any>;
 						public asArray(): java.util.List<any>;
 					}
 				}
@@ -4006,16 +4604,27 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module fleece {
-					export class FLArrayIterator {
+					export abstract class FLArrayIterator extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLArrayIterator>;
 						public constructor();
 						public begin(param0: com.couchbase.lite.internal.fleece.FLArray): void;
 						public constructor(param0: number);
 						public getValue(): com.couchbase.lite.internal.fleece.FLValue;
-						public free(): void;
+						public static getUnmanagedArrayIterator(param0: number): com.couchbase.lite.internal.fleece.FLArrayIterator;
+						public static getManagedArrayIterator(): com.couchbase.lite.internal.fleece.FLArrayIterator;
 						public next(): boolean;
 						public getValueAt(param0: number): com.couchbase.lite.internal.fleece.FLValue;
-						public finalize(): void;
+					}
+					export module FLArrayIterator {
+						export class ManagedFLArrayIterator extends com.couchbase.lite.internal.fleece.FLArrayIterator {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLArrayIterator.ManagedFLArrayIterator>;
+							public close(): void;
+							public finalize(): void;
+						}
+						export class UnmanagedFLArrayIterator extends com.couchbase.lite.internal.fleece.FLArrayIterator {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLArrayIterator.UnmanagedFLArrayIterator>;
+							public close(): void;
+						}
 					}
 				}
 			}
@@ -4086,12 +4695,13 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module fleece {
-					export class FLDictIterator {
+					export class FLDictIterator extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLDictIterator>;
 						public constructor();
 						public begin(param0: com.couchbase.lite.internal.fleece.FLDict): void;
+						public close(): void;
+						public constructor(param0: number);
 						public getValue(): com.couchbase.lite.internal.fleece.FLValue;
-						public free(): void;
 						public getCount(): number;
 						public next(): boolean;
 						public getKeyString(): string;
@@ -4130,29 +4740,41 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module fleece {
-					export class FLEncoder {
+					export abstract class FLEncoder extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLEncoder>;
-						public constructor();
+						public arguments: java.util.Map<string,any>;
 						public writeKey(param0: string): boolean;
-						public managed(): com.couchbase.lite.internal.fleece.FLEncoder;
+						public finish2Unmanaged(): com.couchbase.lite.internal.fleece.FLSliceResult;
 						public beginArray(param0: number): boolean;
-						public finish(): native.Array<number>;
-						public getExtraInfo(): any;
+						public close(): void;
 						public writeString(param0: string): boolean;
-						public writeData(param0: native.Array<number>): boolean;
+						public finish(): androidNative.Array<number>;
+						public getArg(param0: string): any;
 						public endArray(): boolean;
-						public write(param0: java.util.List): boolean;
-						public finalize(): void;
+						public toString(): string;
+						public static getUnmanagedEncoder(param0: number): com.couchbase.lite.internal.fleece.FLEncoder;
+						public static getManagedEncoder(): com.couchbase.lite.internal.fleece.FLEncoder;
 						public endDict(): boolean;
-						public setExtraInfo(param0: any): void;
-						public constructor(param0: number);
-						public free(): void;
+						public setArg(param0: string, param1: any): com.couchbase.lite.internal.fleece.FLEncoder;
+						public writeData(param0: androidNative.Array<number>): boolean;
 						public beginDict(param0: number): boolean;
+						public write(param0: java.util.List<any>): boolean;
 						public finish2(): com.couchbase.lite.internal.fleece.FLSliceResult;
 						public writeValue(param0: any): boolean;
 						public writeNull(): boolean;
 						public write(param0: java.util.Map<string,any>): boolean;
 						public reset(): void;
+					}
+					export module FLEncoder {
+						export class ManagedFLEncoder extends com.couchbase.lite.internal.fleece.FLEncoder {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLEncoder.ManagedFLEncoder>;
+							public close(): void;
+							public finalize(): void;
+						}
+						export class UnmanagedFLEncoder extends com.couchbase.lite.internal.fleece.FLEncoder {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLEncoder.UnmanagedFLEncoder>;
+							public close(): void;
+						}
 					}
 				}
 			}
@@ -4181,17 +4803,28 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module fleece {
-					export class FLSliceResult extends com.couchbase.lite.internal.fleece.AllocSlice {
+					export abstract class FLSliceResult extends com.couchbase.lite.internal.core.C4NativePeer {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLSliceResult>;
-						public constructor();
-						public constructor(param0: native.Array<number>);
+						public static getUnmanagedSliceResult(): com.couchbase.lite.internal.fleece.FLSliceResult;
+						public static getUnmanagedSliceResult(param0: number): com.couchbase.lite.internal.fleece.FLSliceResult;
 						public getSize(): number;
-						public managed(): com.couchbase.lite.internal.fleece.FLSliceResult;
-						public constructor(param0: number);
-						public free(): void;
-						public getBuf(): native.Array<number>;
+						public static getManagedSliceResult(param0: number): com.couchbase.lite.internal.fleece.FLSliceResult;
+						public close(): void;
+						public static getManagedSliceResult(): com.couchbase.lite.internal.fleece.FLSliceResult;
+						public getBuf(): androidNative.Array<number>;
+						public toString(): string;
 						public getHandle(): number;
-						public finalize(): void;
+					}
+					export module FLSliceResult {
+						export class ManagedFLSliceResult extends com.couchbase.lite.internal.fleece.FLSliceResult {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLSliceResult.ManagedFLSliceResult>;
+							public close(): void;
+							public finalize(): void;
+						}
+						export class UnmanagedFLSliceResult extends com.couchbase.lite.internal.fleece.FLSliceResult {
+							public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLSliceResult.UnmanagedFLSliceResult>;
+							public close(): void;
+						}
 					}
 				}
 			}
@@ -4207,31 +4840,50 @@ declare module com {
 					export class FLValue {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.FLValue>;
 						public asBool(): boolean;
-						public static fromData(param0: com.couchbase.lite.internal.fleece.AllocSlice): com.couchbase.lite.internal.fleece.FLValue;
 						public isInteger(): boolean;
-						public static fromData(param0: native.Array<number>): com.couchbase.lite.internal.fleece.FLValue;
+						public static getJSONForJSON5(param0: string): string;
 						public asObject(): any;
+						public static fromData(param0: com.couchbase.lite.internal.fleece.FLSliceResult): com.couchbase.lite.internal.fleece.FLValue;
 						public asInt(): number;
-						public static json5ToJson(param0: string): string;
 						public asDict(): java.util.Map<string,any>;
+						public asData(): androidNative.Array<number>;
 						public static toObject(param0: com.couchbase.lite.internal.fleece.FLValue): any;
 						public getType(): number;
 						public isUnsigned(): boolean;
 						public toStr(): string;
 						public isNumber(): boolean;
 						public asFLDict(): com.couchbase.lite.internal.fleece.FLDict;
+						public static fromData(param0: androidNative.Array<number>): com.couchbase.lite.internal.fleece.FLValue;
 						public constructor(param0: number);
 						public asDouble(): number;
-						public asTypedArray(): java.util.List;
+						public asTypedArray(): java.util.List<any>;
 						public asString(): string;
-						public asFLArray(): com.couchbase.lite.internal.fleece.FLArray;
 						public asArray(): java.util.List<any>;
-						public asData(): native.Array<number>;
 						public toJSON5(): string;
 						public asUnsigned(): number;
 						public asFloat(): number;
 						public isDouble(): boolean;
 						public toJSON(): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module fleece {
+					export class JSONEncoder extends com.couchbase.lite.internal.fleece.FLEncoder.ManagedFLEncoder {
+						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.JSONEncoder>;
+						public finishJSON(): string;
+						public constructor();
+						public finish2Unmanaged(): com.couchbase.lite.internal.fleece.FLSliceResult;
+						public finish(): androidNative.Array<number>;
+						public constructor(param0: number);
+						public finish2(): com.couchbase.lite.internal.fleece.FLSliceResult;
 					}
 				}
 			}
@@ -4258,7 +4910,6 @@ declare module com {
 						public append(param0: any): boolean;
 						public get(param0: number): com.couchbase.lite.internal.fleece.MValue;
 						public initAsCopyOf(param0: com.couchbase.lite.internal.fleece.MArray, param1: boolean): void;
-						public constructor(param0: com.couchbase.lite.internal.fleece.MContext, param1: boolean);
 						public initInSlot(param0: com.couchbase.lite.internal.fleece.MValue, param1: com.couchbase.lite.internal.fleece.MCollection): void;
 						public remove(param0: number): boolean;
 						public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
@@ -4285,7 +4936,6 @@ declare module com {
 						public isMutated(): boolean;
 						public hasMutableChildren(): boolean;
 						public isMutable(): boolean;
-						public constructor(param0: com.couchbase.lite.internal.fleece.MContext, param1: boolean);
 						public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
 					}
 				}
@@ -4303,8 +4953,6 @@ declare module com {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.MContext>;
 						public static NULL: com.couchbase.lite.internal.fleece.MContext;
 						public constructor();
-						public constructor(param0: com.couchbase.lite.internal.fleece.AllocSlice);
-						public getData(): com.couchbase.lite.internal.fleece.AllocSlice;
 					}
 				}
 			}
@@ -4319,19 +4967,17 @@ declare module com {
 				export module fleece {
 					export class MDict extends com.couchbase.lite.internal.fleece.MCollection implements java.lang.Iterable<string>  {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.MDict>;
-						public initAsCopyOf(param0: com.couchbase.lite.internal.fleece.MCollection, param1: boolean): void;
 						public clear(): boolean;
 						public constructor();
 						public count(): number;
 						public remove(param0: string): boolean;
 						public getKeys(): java.util.List<string>;
-						public initAsCopyOf(param0: com.couchbase.lite.internal.fleece.MDict, param1: boolean): void;
+						public constructor(param0: com.couchbase.lite.internal.fleece.MDict, param1: boolean);
+						public constructor(param0: com.couchbase.lite.internal.fleece.MValue, param1: com.couchbase.lite.internal.fleece.MCollection);
 						public initInSlot(param0: com.couchbase.lite.internal.fleece.MValue, param1: com.couchbase.lite.internal.fleece.MCollection, param2: boolean): void;
 						public set(param0: string, param1: com.couchbase.lite.internal.fleece.MValue): boolean;
 						public contains(param0: string): boolean;
 						public iterator(): java.util.Iterator<string>;
-						public constructor(param0: com.couchbase.lite.internal.fleece.MContext, param1: boolean);
-						public initInSlot(param0: com.couchbase.lite.internal.fleece.MValue, param1: com.couchbase.lite.internal.fleece.MCollection): void;
 						public get(param0: string): com.couchbase.lite.internal.fleece.MValue;
 						public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
 					}
@@ -4348,14 +4994,11 @@ declare module com {
 				export module fleece {
 					export class MRoot extends com.couchbase.lite.internal.fleece.MCollection {
 						public static class: java.lang.Class<com.couchbase.lite.internal.fleece.MRoot>;
-						public encode(): com.couchbase.lite.internal.fleece.AllocSlice;
+						public encode(): com.couchbase.lite.internal.fleece.FLSliceResult;
 						public constructor();
-						public constructor(param0: com.couchbase.lite.internal.fleece.AllocSlice, param1: boolean);
 						public constructor(param0: com.couchbase.lite.internal.fleece.MContext, param1: com.couchbase.lite.internal.fleece.FLValue, param2: boolean);
-						public constructor(param0: com.couchbase.lite.internal.fleece.AllocSlice);
 						public asNative(): any;
 						public isMutated(): boolean;
-						public constructor(param0: com.couchbase.lite.internal.fleece.MContext, param1: boolean);
 						public encodeTo(param0: com.couchbase.lite.internal.fleece.FLEncoder): void;
 					}
 				}
@@ -4411,22 +5054,52 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module replicator {
-					export class AbstractCBLWebSocket extends com.couchbase.lite.internal.core.C4Socket {
+					export abstract class AbstractCBLTrustManager {
+						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLTrustManager>;
+						public useCBLTrustManagement(): boolean;
+						public getDefaultTrustManager(): javax.net.ssl.X509TrustManager;
+						public asList(param0: androidNative.Array<java.security.cert.X509Certificate>): java.util.List<java.security.cert.X509Certificate>;
+						public getAcceptedIssuers(): androidNative.Array<java.security.cert.X509Certificate>;
+						public notifyListener(param0: java.util.List<java.security.cert.X509Certificate>): void;
+						public cBLServerTrustCheck(param0: java.util.List<java.security.cert.X509Certificate>, param1: string): void;
+						public constructor(param0: androidNative.Array<number>, param1: boolean, param2: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
+						public checkClientTrusted(param0: androidNative.Array<java.security.cert.X509Certificate>, param1: string): void;
+						public checkServerTrusted(param0: androidNative.Array<java.security.cert.X509Certificate>, param1: string): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module replicator {
+					export abstract class AbstractCBLWebSocket extends com.couchbase.lite.internal.core.C4Socket {
 						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket>;
-						public requestClose(param0: number, param1: string): void;
+						public static DEFAULT_HEARTBEAT_SEC: number;
+						public constructor();
 						public handleClose(param0: java.lang.Throwable): boolean;
 						public close(): void;
-						public constructor(param0: number);
-						public constructor(param0: number, param1: string, param2: string, param3: number, param4: string, param5: java.util.Map<string,any>);
-						public static createCBLWebSocket(param0: number, param1: string, param2: string, param3: number, param4: string, param5: native.Array<number>): com.couchbase.lite.internal.replicator.CBLWebSocket;
-						public openSocket(): void;
-						public completedReceive(param0: number): void;
+						public send(param0: androidNative.Array<number>): void;
+						public getOptions(): java.util.Map<string,any>;
 						public constructor(param0: string, param1: string, param2: number, param3: string, param4: number);
-						public send(param0: native.Array<number>): void;
+						public handleCloseCause(param0: java.lang.Throwable): number;
+						public toString(): string;
+						public requestClose(param0: number, param1: string): void;
+						public constructor(param0: number);
+						public constructor(param0: number, param1: java.net.URI, param2: androidNative.Array<number>, param3: com.couchbase.lite.internal.replicator.CBLCookieStore, param4: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
+						public openSocket(): void;
+						public closeSocket(): void;
+						public static addKeyManager(param0: javax.net.ssl.KeyManager): number;
+						public completedReceive(param0: number): void;
+						public getOkHttpSocketFactory(): okhttp3.OkHttpClient;
 					}
 					export module AbstractCBLWebSocket {
-						export class CBLWebSocketListener {
-							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.CBLWebSocketListener>;
+						export class OkHttpRemote {
+							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.OkHttpRemote>;
 							public onMessage(param0: okhttp3.WebSocket, param1: okio.ByteString): void;
 							public onOpen(param0: okhttp3.WebSocket, param1: okhttp3.Response): void;
 							public onMessage(param0: okhttp3.WebSocket, param1: string): void;
@@ -4434,16 +5107,83 @@ declare module com {
 							public onClosing(param0: okhttp3.WebSocket, param1: number, param2: string): void;
 							public onClosed(param0: okhttp3.WebSocket, param1: number, param2: string): void;
 						}
-						export class TLSSocketFactory {
-							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.TLSSocketFactory>;
-							public createSocket(param0: java.net.InetAddress, param1: number): java.net.Socket;
-							public createSocket(param0: java.net.InetAddress, param1: number, param2: java.net.InetAddress, param3: number): java.net.Socket;
-							public createSocket(param0: java.net.Socket, param1: string, param2: number, param3: boolean): java.net.Socket;
-							public getSupportedCipherSuites(): native.Array<string>;
-							public createSocket(param0: string, param1: number, param2: java.net.InetAddress, param3: number): java.net.Socket;
-							public getDefaultCipherSuites(): native.Array<string>;
-							public createSocket(param0: string, param1: number): java.net.Socket;
+						export class State {
+							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State>;
+							public static INIT: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static CONNECTING: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static OPEN: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static CLOSE_REQUESTED: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static CLOSING: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static CLOSED: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static FAILED: com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static valueOf(param0: string): com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State;
+							public static values(): androidNative.Array<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.State>;
 						}
+						export class WebSocketCookieJar {
+							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AbstractCBLWebSocket.WebSocketCookieJar>;
+							public loadForRequest(param0: okhttp3.HttpUrl): java.util.List<okhttp3.Cookie>;
+							public saveFromResponse(param0: okhttp3.HttpUrl, param1: java.util.List<okhttp3.Cookie>): void;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module replicator {
+					export class AndroidConnectivityObserver extends com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer {
+						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.AndroidConnectivityObserver>;
+						public constructor(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager, param1: com.couchbase.lite.internal.utils.Fn.Provider<com.couchbase.lite.internal.core.C4Replicator>);
+						public handleOffline(param0: com.couchbase.lite.ReplicatorActivityLevel, param1: boolean): void;
+						public onConnectivityChanged(param0: boolean): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module replicator {
+					export class CBLCookieStore {
+						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.CBLCookieStore>;
+						/**
+						 * Constructs a new instance of the com.couchbase.lite.internal.replicator.CBLCookieStore interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {
+							parseCookies(param0: okhttp3.HttpUrl, param1: string): java.util.List<okhttp3.Cookie>;
+							setCookie(param0: java.net.URI, param1: string): void;
+							getCookies(param0: java.net.URI): string;
+						});
+						public constructor();
+						public setCookie(param0: java.net.URI, param1: string): void;
+						public getCookies(param0: java.net.URI): string;
+						public static parseCookies(param0: okhttp3.HttpUrl, param1: string): java.util.List<okhttp3.Cookie>;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module replicator {
+					export class CBLTrustManager extends com.couchbase.lite.internal.replicator.AbstractCBLTrustManager {
+						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.CBLTrustManager>;
+						public checkServerTrusted(param0: androidNative.Array<java.security.cert.X509Certificate>, param1: string, param2: string): java.util.List<java.security.cert.X509Certificate>;
+						public constructor(param0: androidNative.Array<number>, param1: boolean, param2: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
+						public checkServerTrusted(param0: androidNative.Array<java.security.cert.X509Certificate>, param1: string): void;
 					}
 				}
 			}
@@ -4458,10 +5198,51 @@ declare module com {
 				export module replicator {
 					export class CBLWebSocket extends com.couchbase.lite.internal.replicator.AbstractCBLWebSocket {
 						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.CBLWebSocket>;
+						public constructor();
 						public handleClose(param0: java.lang.Throwable): boolean;
 						public constructor(param0: number);
-						public constructor(param0: number, param1: string, param2: string, param3: number, param4: string, param5: java.util.Map<string,any>);
+						public constructor(param0: number, param1: java.net.URI, param2: androidNative.Array<number>, param3: com.couchbase.lite.internal.replicator.CBLCookieStore, param4: com.couchbase.lite.internal.utils.Fn.Consumer<java.util.List<java.security.cert.Certificate>>);
 						public constructor(param0: string, param1: string, param2: number, param3: string, param4: number);
+						public handleCloseCause(param0: java.lang.Throwable): number;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module replicator {
+					export class NetworkConnectivityManager {
+						public static class: java.lang.Class<com.couchbase.lite.internal.replicator.NetworkConnectivityManager>;
+						/**
+						 * Constructs a new instance of the com.couchbase.lite.internal.replicator.NetworkConnectivityManager interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {
+							isConnected(): boolean;
+							registerObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+							unregisterObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+						});
+						public constructor();
+						public unregisterObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+						public isConnected(): boolean;
+						public registerObserver(param0: com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer): void;
+					}
+					export module NetworkConnectivityManager {
+						export class Observer {
+							public static class: java.lang.Class<com.couchbase.lite.internal.replicator.NetworkConnectivityManager.Observer>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.replicator.NetworkConnectivityManager$Observer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								onConnectivityChanged(param0: boolean): void;
+							});
+							public constructor();
+							public onConnectivityChanged(param0: boolean): void;
+						}
 					}
 				}
 			}
@@ -4476,55 +5257,38 @@ declare module com {
 				export module support {
 					export class Log {
 						public static class: java.lang.Class<com.couchbase.lite.internal.support.Log>;
-						public static LOGGING_DOMAINS_FROM_C4: java.util.Map<string,com.couchbase.lite.LogDomain>;
-						public static LOGGING_DOMAINS_TO_C4: java.util.Map<com.couchbase.lite.LogDomain,string>;
-						public static LOG_LEVEL_FROM_C4: java.util.Map<java.lang.Integer,com.couchbase.lite.LogLevel>;
+						public static LOG_HEADER: string;
+						public static e(param0: com.couchbase.lite.LogDomain, param1: string, param2: androidNative.Array<any>): void;
 						public static w(param0: com.couchbase.lite.LogDomain, param1: string): void;
-						public static w(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: native.Array<any>): void;
-						public static i(param0: com.couchbase.lite.LogDomain, param1: string, param2: native.Array<any>): void;
 						public static info(param0: com.couchbase.lite.LogDomain, param1: string): void;
-						public static v(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: native.Array<any>): void;
+						public static formatStandardMessage(param0: string, param1: androidNative.Array<any>): string;
+						public static d(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: androidNative.Array<any>): void;
 						public static e(param0: com.couchbase.lite.LogDomain, param1: string): void;
-						public static formatStandardMessage(param0: string, param1: native.Array<any>): string;
-						public static e(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: native.Array<any>): void;
+						public static getC4LevelForLogLevel(param0: com.couchbase.lite.LogLevel): number;
+						public static i(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: androidNative.Array<any>): void;
 						public static v(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
+						public static w(param0: com.couchbase.lite.LogDomain, param1: string, param2: androidNative.Array<any>): void;
 						public static getC4DomainForLoggingDomain(param0: com.couchbase.lite.LogDomain): string;
+						public static v(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: androidNative.Array<any>): void;
 						public static i(param0: com.couchbase.lite.LogDomain, param1: string): void;
 						public static d(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
-						public static e(param0: com.couchbase.lite.LogDomain, param1: string, param2: native.Array<any>): void;
+						public static i(param0: com.couchbase.lite.LogDomain, param1: string, param2: androidNative.Array<any>): void;
+						public static d(param0: com.couchbase.lite.LogDomain, param1: string, param2: androidNative.Array<any>): void;
 						public static v(param0: com.couchbase.lite.LogDomain, param1: string): void;
-						public static setC4LogLevel(param0: java.util.EnumSet<com.couchbase.lite.LogDomain>, param1: com.couchbase.lite.LogLevel): void;
 						public static w(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
 						public static getLogLevelForC4Level(param0: number): com.couchbase.lite.LogLevel;
 						public static getLoggingDomainForC4Domain(param0: string): com.couchbase.lite.LogDomain;
+						public static initLogging(): void;
 						public static info(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
 						public static initLogging(param0: java.util.Map<string,string>): void;
 						public static i(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
-						public static w(param0: com.couchbase.lite.LogDomain, param1: string, param2: native.Array<any>): void;
+						public static w(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: androidNative.Array<any>): void;
 						public static d(param0: com.couchbase.lite.LogDomain, param1: string): void;
-						public static v(param0: com.couchbase.lite.LogDomain, param1: string, param2: native.Array<any>): void;
 						public static warn(): void;
-						public static d(param0: com.couchbase.lite.LogDomain, param1: string, param2: native.Array<any>): void;
+						public static v(param0: com.couchbase.lite.LogDomain, param1: string, param2: androidNative.Array<any>): void;
 						public static lookupStandardMessage(param0: string): string;
-						public static i(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: native.Array<any>): void;
+						public static e(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: androidNative.Array<any>): void;
 						public static e(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable): void;
-						public static d(param0: com.couchbase.lite.LogDomain, param1: string, param2: java.lang.Throwable, param3: native.Array<any>): void;
-					}
-				}
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export module internal {
-				export module support {
-					export class Run {
-						public static class: java.lang.Class<com.couchbase.lite.internal.support.Run>;
-						public constructor();
-						public static once(param0: string, param1: java.lang.Runnable): void;
 					}
 				}
 			}
@@ -4539,7 +5303,8 @@ declare module com {
 				export module utils {
 					export class ClassUtils {
 						public static class: java.lang.Class<com.couchbase.lite.internal.utils.ClassUtils>;
-						public static cast(param0: any, param1: java.lang.Class): any;
+						public static castOrNull(param0: java.lang.Class<any>, param1: any): any;
+						public static objId(param0: any): string;
 					}
 				}
 			}
@@ -4552,10 +5317,16 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module utils {
-					export class DateUtils {
-						public static class: java.lang.Class<com.couchbase.lite.internal.utils.DateUtils>;
-						public static fromJson(param0: string): java.util.Date;
-						public static toJson(param0: java.util.Date): string;
+					export class FileUtils {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.FileUtils>;
+						public static eraseFileOrDir(param0: java.io.File): boolean;
+						public static setPermissionRecursive(param0: java.io.File, param1: boolean, param2: boolean): boolean;
+						public static verifyDir(param0: java.io.File): java.io.File;
+						public static copyFile(param0: java.io.InputStream, param1: java.io.OutputStream): void;
+						public static deleteContents(param0: java.io.File): boolean;
+						public static eraseFileOrDir(param0: string): boolean;
+						public static deleteContents(param0: string): boolean;
+						public static verifyDir(param0: string): java.io.File;
 					}
 				}
 			}
@@ -4568,12 +5339,247 @@ declare module com {
 		export module lite {
 			export module internal {
 				export module utils {
-					export class JsonUtils {
-						public static class: java.lang.Class<com.couchbase.lite.internal.utils.JsonUtils>;
-						public static fromJson(param0: org.json.JSONArray): java.util.List<any>;
-						public static toJson(param0: java.util.List<any>): org.json.JSONArray;
-						public static toJson(param0: java.util.Map<string,any>): org.json.JSONObject;
-						public static fromJson(param0: org.json.JSONObject): java.util.Map<string,any>;
+					export class Fn {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn>;
+						/**
+						 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {
+						});
+						public constructor();
+					}
+					export module Fn {
+						export class Consumer<T>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.Consumer<any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$Consumer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								accept(param0: T): void;
+							});
+							public constructor();
+							public accept(param0: T): void;
+						}
+						export class ConsumerThrows<T, E>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.ConsumerThrows<any,any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$ConsumerThrows interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								accept(param0: T): void;
+							});
+							public constructor();
+							public accept(param0: T): void;
+						}
+						export class Function<T, R>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.Function<any,any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$Function interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								apply(param0: T): R;
+							});
+							public constructor();
+							public apply(param0: T): R;
+						}
+						export class FunctionThrows<T, R, E>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.FunctionThrows<any,any,any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$FunctionThrows interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								apply(param0: T): R;
+							});
+							public constructor();
+							public apply(param0: T): R;
+						}
+						export class Predicate<T>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.Predicate<any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$Predicate interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								test(param0: T): boolean;
+							});
+							public constructor();
+							public test(param0: T): boolean;
+						}
+						export class Provider<T>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.Provider<any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$Provider interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								get(): T;
+							});
+							public constructor();
+							public get(): T;
+						}
+						export class ProviderThrows<T, E>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.ProviderThrows<any,any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$ProviderThrows interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								get(): T;
+							});
+							public constructor();
+							public get(): T;
+						}
+						export class Runner {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.Runner>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$Runner interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								run(param0: java.lang.Runnable): void;
+							});
+							public constructor();
+							public run(param0: java.lang.Runnable): void;
+						}
+						export class TaskThrows<E>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.Fn.TaskThrows<any>>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.Fn$TaskThrows interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								run(): void;
+							});
+							public constructor();
+							public run(): void;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class Internal {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.Internal>;
+						/**
+						 * Constructs a new instance of the com.couchbase.lite.internal.utils.Internal interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {
+							value(): string;
+						});
+						public constructor();
+						public value(): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class JSONUtils {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.JSONUtils>;
+						public static fromJSON(param0: org.json.JSONObject): java.util.Map<string,any>;
+						public static fromJSON(param0: org.json.JSONArray): java.util.List<any>;
+						public static toDate(param0: string): java.util.Date;
+						public static toJSON(param0: any): any;
+						public static toJSON(param0: java.util.Map<any,any>): org.json.JSONObject;
+						public static toJSON(param0: java.util.List<any>): org.json.JSONArray;
+						public static toJSONString(param0: java.util.Date): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class MathUtils {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.MathUtils>;
+						public static RANDOM: java.lang.ThreadLocal<java.util.Random>;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class PlatformUtils {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.PlatformUtils>;
+						public static getAsset(param0: string): java.io.InputStream;
+						public static getEncoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Encoder;
+						public static getDecoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Decoder;
+					}
+					export module PlatformUtils {
+						export class Base64Decoder {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.PlatformUtils.Base64Decoder>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.PlatformUtils$Base64Decoder interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								decodeString(param0: string): androidNative.Array<number>;
+							});
+							public constructor();
+							public decodeString(param0: string): androidNative.Array<number>;
+						}
+						export class Base64Encoder {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.PlatformUtils.Base64Encoder>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.PlatformUtils$Base64Encoder interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								encodeToString(param0: androidNative.Array<number>): string;
+							});
+							public constructor();
+							public encodeToString(param0: androidNative.Array<number>): string;
+						}
+						export class Delegate {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.PlatformUtils.Delegate>;
+							/**
+							 * Constructs a new instance of the com.couchbase.lite.internal.utils.PlatformUtils$Delegate interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {
+								getAsset(param0: string): java.io.InputStream;
+								getEncoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Encoder;
+								getDecoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Decoder;
+							});
+							public constructor();
+							public getAsset(param0: string): java.io.InputStream;
+							public getDecoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Decoder;
+							public getEncoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Encoder;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class PlatformUtilsDelegate extends com.couchbase.lite.internal.utils.PlatformUtils.Delegate {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.PlatformUtilsDelegate>;
+						public constructor();
+						public getEncoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Encoder;
+						public getDecoder(): com.couchbase.lite.internal.utils.PlatformUtils.Base64Decoder;
+						public getAsset(param0: string): java.io.InputStream;
 					}
 				}
 			}
@@ -4588,9 +5594,40 @@ declare module com {
 				export module utils {
 					export class Preconditions {
 						public static class: java.lang.Class<com.couchbase.lite.internal.utils.Preconditions>;
-						public static checkArgNotZero(param0: number, param1: string): void;
-						public static checkArgNotNull(param0: any, param1: string): void;
-						public static testArg(param0: any, param1: string, param2: com.couchbase.lite.utils.Fn.Predicate<any>): void;
+						public static assertNotEmpty(param0: string, param1: string): string;
+						public static assertThat(param0: any, param1: string, param2: com.couchbase.lite.internal.utils.Fn.Predicate<any>): any;
+						public static assertNotNegative(param0: number, param1: string): number;
+						public static assertNegative(param0: number, param1: string): number;
+						public static assertZero(param0: number, param1: string): number;
+						public static assertNotZero(param0: number, param1: string): number;
+						public static assertPositive(param0: number, param1: string): number;
+						public static assertNotNull(param0: any, param1: string): any;
+						public static assertNotEmpty(param0: java.util.Collection<any>, param1: string): java.util.Collection<any>;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module com {
+	export module couchbase {
+		export module lite {
+			export module internal {
+				export module utils {
+					export class StateMachine<T>  extends java.lang.Object {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.StateMachine<any>>;
+						public assertState(param0: androidNative.Array<T>): boolean;
+						public toString(): string;
+						public setState(param0: T): boolean;
+					}
+					export module StateMachine {
+						export class Builder<S>  extends java.lang.Object {
+							public static class: java.lang.Class<com.couchbase.lite.internal.utils.StateMachine.Builder<any>>;
+							public addTransition(param0: S, param1: S, param2: androidNative.Array<S>): com.couchbase.lite.internal.utils.StateMachine.Builder<S>;
+							public build(): com.couchbase.lite.internal.utils.StateMachine<S>;
+							public constructor(param0: java.lang.Class<S>, param1: S, param2: S);
+						}
 					}
 				}
 			}
@@ -4605,8 +5642,15 @@ declare module com {
 				export module utils {
 					export class StringUtils {
 						public static class: java.lang.Class<com.couchbase.lite.internal.utils.StringUtils>;
+						public static ALPHA: string;
+						public static NUMERIC: string;
+						public static ALPHANUMERIC: string;
+						public static getUniqueName(param0: string, param1: number): string;
+						public static getArrayString(param0: androidNative.Array<string>, param1: number): string;
+						public static join(param0: string, param1: java.lang.Iterable<any>): string;
+						public static randomString(param0: number): string;
 						public static isEmpty(param0: string): boolean;
-						public static join(param0: string, param1: java.lang.Iterable): string;
+						public static toString(param0: java.util.Map<any,any>): string;
 					}
 				}
 			}
@@ -4617,119 +5661,39 @@ declare module com {
 declare module com {
 	export module couchbase {
 		export module lite {
-			export module utils {
-				export class FileUtils {
-					public static class: java.lang.Class<com.couchbase.lite.utils.FileUtils>;
-					public static cleanDirectory(param0: java.io.File): boolean;
-					public static deleteRecursive(param0: string): boolean;
-					public constructor();
-					public static removeItemIfExists(param0: string): boolean;
-					public static deleteRecursive(param0: java.io.File): boolean;
-					public static setPermissionRecursive(param0: java.io.File, param1: boolean, param2: boolean): boolean;
-				}
-			}
-		}
-	}
-}
-
-declare module com {
-	export module couchbase {
-		export module lite {
-			export module utils {
-				export class Fn {
-					public static class: java.lang.Class<com.couchbase.lite.utils.Fn>;
-					/**
-					 * Constructs a new instance of the com.couchbase.lite.utils.Fn interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-					 */
-					public constructor(implementation: {
-					});
-					public constructor();
-				}
-				export module Fn {
-					export class Consumer<T>  extends java.lang.Object {
-						public static class: java.lang.Class<com.couchbase.lite.utils.Fn.Consumer<any>>;
+			export module internal {
+				export module utils {
+					export class Volatile {
+						public static class: java.lang.Class<com.couchbase.lite.internal.utils.Volatile>;
 						/**
-						 * Constructs a new instance of the com.couchbase.lite.utils.Fn$Consumer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 * Constructs a new instance of the com.couchbase.lite.internal.utils.Volatile interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
 						 */
 						public constructor(implementation: {
-							accept(param0: T): void;
 						});
 						public constructor();
-						public accept(param0: T): void;
-					}
-					export class Function<T, R>  extends java.lang.Object {
-						public static class: java.lang.Class<com.couchbase.lite.utils.Fn.Function<any,any>>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.utils.Fn$Function interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							apply(param0: T): R;
-						});
-						public constructor();
-						public apply(param0: T): R;
-					}
-					export class FunctionThrows<T, R, E>  extends java.lang.Object {
-						public static class: java.lang.Class<com.couchbase.lite.utils.Fn.FunctionThrows<any,any,any>>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.utils.Fn$FunctionThrows interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							apply(param0: T): R;
-						});
-						public constructor();
-						public apply(param0: T): R;
-					}
-					export class Predicate<T>  extends java.lang.Object {
-						public static class: java.lang.Class<com.couchbase.lite.utils.Fn.Predicate<any>>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.utils.Fn$Predicate interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							test(param0: T): boolean;
-						});
-						public constructor();
-						public test(param0: T): boolean;
-					}
-					export class Provider<T>  extends java.lang.Object {
-						public static class: java.lang.Class<com.couchbase.lite.utils.Fn.Provider<any>>;
-						/**
-						 * Constructs a new instance of the com.couchbase.lite.utils.Fn$Provider interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-						 */
-						public constructor(implementation: {
-							get(): T;
-						});
-						public constructor();
-						public get(): T;
 					}
 				}
-			}
-		}
-	}
-}
-
-declare module okhttp3 {
-	export module internal {
-		export module tls {
-			export class CustomHostnameVerifier {
-				public static class: java.lang.Class<okhttp3.internal.tls.CustomHostnameVerifier>;
-				public static INSTANCE: okhttp3.internal.tls.CustomHostnameVerifier;
-				public verify(param0: string, param1: javax.net.ssl.SSLSession): boolean;
-				public verifyHostname(param0: string, param1: string): boolean;
-				public static allSubjectAltNames(param0: java.security.cert.X509Certificate): java.util.List<string>;
-				public static getInstance(): okhttp3.internal.tls.CustomHostnameVerifier;
-				public verify(param0: string, param1: java.security.cert.X509Certificate): boolean;
 			}
 		}
 	}
 }
 
 //Generics information:
+//com.couchbase.lite.AbstractDatabase.ActiveProcess:1
 //com.couchbase.lite.ChangeListener:1
 //com.couchbase.lite.ChangeListenerToken:1
 //com.couchbase.lite.ChangeNotifier:1
-//com.couchbase.lite.utils.Fn.Consumer:1
-//com.couchbase.lite.utils.Fn.Function:2
-//com.couchbase.lite.utils.Fn.FunctionThrows:3
-//com.couchbase.lite.utils.Fn.Predicate:1
-//com.couchbase.lite.utils.Fn.Provider:1
+//com.couchbase.lite.UnitOfWork:1
+//com.couchbase.lite.internal.core.NativeContext:1
+//com.couchbase.lite.internal.exec.ClientTask:1
+//com.couchbase.lite.internal.utils.Fn.Consumer:1
+//com.couchbase.lite.internal.utils.Fn.ConsumerThrows:2
+//com.couchbase.lite.internal.utils.Fn.Function:2
+//com.couchbase.lite.internal.utils.Fn.FunctionThrows:3
+//com.couchbase.lite.internal.utils.Fn.Predicate:1
+//com.couchbase.lite.internal.utils.Fn.Provider:1
+//com.couchbase.lite.internal.utils.Fn.ProviderThrows:2
+//com.couchbase.lite.internal.utils.Fn.TaskThrows:1
+//com.couchbase.lite.internal.utils.StateMachine:1
+//com.couchbase.lite.internal.utils.StateMachine.Builder:1
 

--- a/packages/nativescript-couchbase/typings/objc!CouchbaseLite.d.ts
+++ b/packages/nativescript-couchbase/typings/objc!CouchbaseLite.d.ts
@@ -1,4 +1,3 @@
- // Generated with v2.8.1
 
 declare class CBLArray extends NSObject implements CBLArrayProtocol, NSCopying, NSMutableCopying {
 
@@ -74,6 +73,8 @@ declare class CBLArray extends NSObject implements CBLArrayProtocol, NSCopying, 
 
 	toArray(): NSArray<any>;
 
+	toJSON(): string;
+
 	toMutable(): CBLMutableArray;
 
 	valueAtIndex(index: number): any;
@@ -116,6 +117,8 @@ interface CBLArrayProtocol extends CBLArrayFragment, NSFastEnumeration, NSObject
 
 	toArray(): NSArray<any>;
 
+	toJSON(): string;
+
 	valueAtIndex(index: number): any;
 }
 declare var CBLArrayProtocol: {
@@ -149,6 +152,8 @@ declare class CBLBlob extends NSObject {
 
 	static alloc(): CBLBlob; // inherited from NSObject
 
+	static isBlob(properties: NSDictionary<string, any>): boolean;
+
 	static new(): CBLBlob; // inherited from NSObject
 
 	readonly content: NSData;
@@ -174,6 +179,8 @@ declare class CBLBlob extends NSObject {
 	initWithContentTypeData(contentType: string, data: NSData): this;
 
 	initWithContentTypeFileURLError(contentType: string, fileURL: NSURL): this;
+
+	toJSON(): string;
 }
 
 declare const enum CBLConcurrencyControl {
@@ -275,8 +282,6 @@ declare class CBLDatabase extends NSObject {
 
 	static new(): CBLDatabase; // inherited from NSObject
 
-	static setLogLevelDomain(level: CBLLogLevel, domain: CBLLogDomain): void;
-
 	readonly config: CBLDatabaseConfiguration;
 
 	readonly count: number;
@@ -301,9 +306,11 @@ declare class CBLDatabase extends NSObject {
 
 	close(): boolean;
 
-	compact(): boolean;
+	createIndexWithConfigNameError(config: CBLIndexConfiguration, name: string): boolean;
 
 	createIndexWithNameError(index: CBLIndex, name: string): boolean;
+
+	createQueryError(query: string): CBLQuery;
 
 	delete(): boolean;
 
@@ -314,6 +321,8 @@ declare class CBLDatabase extends NSObject {
 	deleteIndexForNameError(name: string): boolean;
 
 	documentWithID(id: string): CBLDocument;
+
+	getBlob(properties: NSDictionary<any, any>): CBLBlob;
 
 	getDocumentExpirationWithID(documentID: string): Date;
 
@@ -332,6 +341,8 @@ declare class CBLDatabase extends NSObject {
 	purgeDocumentWithIDError(documentID: string): boolean;
 
 	removeChangeListenerWithToken(token: CBLListenerToken): void;
+
+	saveBlobError(blob: CBLBlob): boolean;
 
 	saveDocumentConcurrencyControlError(document: CBLMutableDocument, concurrencyControl: CBLConcurrencyControl): boolean;
 
@@ -443,6 +454,8 @@ declare class CBLDictionary extends NSObject implements CBLDictionaryProtocol, N
 
 	toDictionary(): NSDictionary<string, any>;
 
+	toJSON(): string;
+
 	toMutable(): CBLMutableDictionary;
 
 	valueForKey(key: string): any;
@@ -488,6 +501,8 @@ interface CBLDictionaryProtocol extends CBLDictionaryFragment, NSFastEnumeration
 	stringForKey(key: string): string;
 
 	toDictionary(): NSDictionary<string, any>;
+
+	toJSON(): string;
 
 	valueForKey(key: string): any;
 }
@@ -576,6 +591,8 @@ declare class CBLDocument extends NSObject implements CBLDictionaryProtocol, NSM
 	stringForKey(key: string): string;
 
 	toDictionary(): NSDictionary<string, any>;
+
+	toJSON(): string;
 
 	toMutable(): CBLMutableDocument;
 
@@ -718,6 +735,8 @@ declare const CBLErrorHTTPProxyAuthRequired: number;
 declare const CBLErrorHTTPServiceUnavailable: number;
 
 declare const CBLErrorIOError: number;
+
+declare const CBLErrorInvalidJSON: number;
 
 declare const CBLErrorInvalidParameter: number;
 
@@ -960,6 +979,21 @@ declare class CBLFullTextIndex extends CBLIndex {
 	language: string;
 }
 
+declare class CBLFullTextIndexConfiguration extends CBLIndexConfiguration {
+
+	static alloc(): CBLFullTextIndexConfiguration; // inherited from NSObject
+
+	static new(): CBLFullTextIndexConfiguration; // inherited from NSObject
+
+	readonly ignoreAccents: boolean;
+
+	readonly language: string;
+
+	constructor(o: { expression: NSArray<string> | string[]; ignoreAccents: boolean; language: string; });
+
+	initWithExpressionIgnoreAccentsLanguage(expressions: NSArray<string> | string[], ignoreAccents: boolean, language: string): this;
+}
+
 declare class CBLFullTextIndexItem extends NSObject {
 
 	static alloc(): CBLFullTextIndexItem; // inherited from NSObject
@@ -985,6 +1019,15 @@ declare class CBLIndexBuilder extends NSObject {
 	static new(): CBLIndexBuilder; // inherited from NSObject
 
 	static valueIndexWithItems(items: NSArray<CBLValueIndexItem> | CBLValueIndexItem[]): CBLValueIndex;
+}
+
+declare class CBLIndexConfiguration extends NSObject {
+
+	static alloc(): CBLIndexConfiguration; // inherited from NSObject
+
+	static new(): CBLIndexConfiguration; // inherited from NSObject
+
+	readonly expressions: NSArray<string>;
 }
 
 interface CBLListenerToken extends NSObjectProtocol {
@@ -1071,7 +1114,11 @@ declare const enum CBLMaintenanceType {
 
 	kCBLMaintenanceTypeReindex = 1,
 
-	kCBLMaintenanceTypeIntegrityCheck = 2
+	kCBLMaintenanceTypeIntegrityCheck = 2,
+
+	kCBLMaintenanceTypeOptimize = 3,
+
+	kCBLMaintenanceTypeFullOptimize = 4
 }
 
 declare class CBLMutableArray extends CBLArray implements CBLMutableArrayProtocol {
@@ -1099,6 +1146,8 @@ declare class CBLMutableArray extends CBLArray implements CBLMutableArrayProtoco
 	[Symbol.iterator](): Iterator<any>;
 
 	constructor(o: { data: NSArray<any> | any[]; });
+
+	constructor(o: { JSON: string; });
 
 	addArray(value: CBLArray): void;
 
@@ -1143,6 +1192,8 @@ declare class CBLMutableArray extends CBLArray implements CBLMutableArrayProtoco
 	floatAtIndex(index: number): number;
 
 	initWithData(data: NSArray<any> | any[]): this;
+
+	initWithJSONError(json: string): this;
 
 	insertArrayAtIndex(value: CBLArray, index: number): void;
 
@@ -1214,6 +1265,8 @@ declare class CBLMutableArray extends CBLArray implements CBLMutableArrayProtoco
 
 	setIntegerAtIndex(value: number, index: number): void;
 
+	setJSONError(json: string): boolean;
+
 	setLongLongAtIndex(value: number, index: number): void;
 
 	setNumberAtIndex(value: number, index: number): void;
@@ -1225,6 +1278,8 @@ declare class CBLMutableArray extends CBLArray implements CBLMutableArrayProtoco
 	stringAtIndex(index: number): string;
 
 	toArray(): NSArray<any>;
+
+	toJSON(): string;
 
 	valueAtIndex(index: number): any;
 }
@@ -1352,6 +1407,8 @@ declare class CBLMutableDictionary extends CBLDictionary implements CBLMutableDi
 
 	constructor(o: { data: NSDictionary<string, any>; });
 
+	constructor(o: { JSON: string; });
+
 	arrayForKey(key: string): CBLMutableArray;
 
 	blobForKey(key: string): CBLBlob;
@@ -1373,6 +1430,8 @@ declare class CBLMutableDictionary extends CBLDictionary implements CBLMutableDi
 	floatForKey(key: string): number;
 
 	initWithData(data: NSDictionary<string, any>): this;
+
+	initWithJSONError(json: string): this;
 
 	integerForKey(key: string): number;
 
@@ -1420,6 +1479,8 @@ declare class CBLMutableDictionary extends CBLDictionary implements CBLMutableDi
 
 	setIntegerForKey(value: number, key: string): void;
 
+	setJSONError(json: string): boolean;
+
 	setLongLongForKey(value: number, key: string): void;
 
 	setNumberForKey(value: number, key: string): void;
@@ -1431,6 +1492,8 @@ declare class CBLMutableDictionary extends CBLDictionary implements CBLMutableDi
 	stringForKey(key: string): string;
 
 	toDictionary(): NSDictionary<string, any>;
+
+	toJSON(): string;
 
 	valueForKey(key: string): any;
 }
@@ -1469,6 +1532,8 @@ interface CBLMutableDictionaryProtocol extends CBLDictionaryProtocol, CBLMutable
 	setFloatForKey(value: number, key: string): void;
 
 	setIntegerForKey(value: number, key: string): void;
+
+	setJSONError(json: string): boolean;
 
 	setLongLongForKey(value: number, key: string): void;
 
@@ -1516,6 +1581,10 @@ declare class CBLMutableDocument extends CBLDocument implements CBLMutableDictio
 
 	constructor(o: { ID: string; data: NSDictionary<string, any>; });
 
+	constructor(o: { ID: string; json: string; });
+
+	constructor(o: { JSON: string; });
+
 	arrayForKey(key: string): CBLMutableArray;
 
 	blobForKey(key: string): CBLBlob;
@@ -1541,6 +1610,10 @@ declare class CBLMutableDocument extends CBLDocument implements CBLMutableDictio
 	initWithID(documentID: string): this;
 
 	initWithIDData(documentID: string, data: NSDictionary<string, any>): this;
+
+	initWithIDJsonError(documentID: string, json: string): this;
+
+	initWithJSONError(json: string): this;
 
 	integerForKey(key: string): number;
 
@@ -1588,6 +1661,8 @@ declare class CBLMutableDocument extends CBLDocument implements CBLMutableDictio
 
 	setIntegerForKey(value: number, key: string): void;
 
+	setJSONError(json: string): boolean;
+
 	setLongLongForKey(value: number, key: string): void;
 
 	setNumberForKey(value: number, key: string): void;
@@ -1599,6 +1674,8 @@ declare class CBLMutableDocument extends CBLDocument implements CBLMutableDictio
 	stringForKey(key: string): string;
 
 	toDictionary(): NSDictionary<string, any>;
+
+	toJSON(): string;
 
 	valueForKey(key: string): any;
 }
@@ -1903,7 +1980,11 @@ declare class CBLQueryExpression extends NSObject {
 
 	isNot(expression: CBLQueryExpression): CBLQueryExpression;
 
+	isNotValued(): CBLQueryExpression;
+
 	isNullOrMissing(): CBLQueryExpression;
+
+	isValued(): CBLQueryExpression;
 
 	lessThan(expression: CBLQueryExpression): CBLQueryExpression;
 
@@ -1941,6 +2022,8 @@ declare class CBLQueryFullTextFunction extends NSObject {
 
 	static alloc(): CBLQueryFullTextFunction; // inherited from NSObject
 
+	static matchWithIndexNameQuery(indexName: string, query: string): CBLQueryExpression;
+
 	static new(): CBLQueryFullTextFunction; // inherited from NSObject
 
 	static rank(indexName: string): CBLQueryExpression;
@@ -1958,7 +2041,7 @@ declare class CBLQueryFunction extends NSObject {
 
 	static atan(expression: CBLQueryExpression): CBLQueryExpression;
 
-	static atan2Y(x: CBLQueryExpression, y: CBLQueryExpression): CBLQueryExpression;
+	static atan2X(y: CBLQueryExpression, x: CBLQueryExpression): CBLQueryExpression;
 
 	static avg(expression: CBLQueryExpression): CBLQueryExpression;
 
@@ -2236,6 +2319,8 @@ declare class CBLQueryResult extends NSObject implements CBLArrayProtocol, CBLDi
 
 	toDictionary(): NSDictionary<string, any>;
 
+	toJSON(): string;
+
 	valueAtIndex(index: number): any;
 
 	valueForKey(key: string): any;
@@ -2330,8 +2415,6 @@ declare class CBLReplicator extends NSObject {
 
 	removeChangeListenerWithToken(token: CBLListenerToken): void;
 
-	resetCheckpoint(): void;
-
 	start(): void;
 
 	startWithReset(reset: boolean): void;
@@ -2383,7 +2466,17 @@ declare class CBLReplicatorConfiguration extends NSObject {
 
 	documentIDs: NSArray<string>;
 
+	enableAutoPurge: boolean;
+
 	headers: NSDictionary<string, string>;
+
+	heartbeat: number;
+
+	maxAttemptWaitTime: number;
+
+	maxAttempts: number;
+
+	networkInterface: string;
 
 	pinnedServerCertificate: any;
 
@@ -2505,6 +2598,17 @@ declare class CBLValueIndex extends CBLIndex {
 	static new(): CBLValueIndex; // inherited from NSObject
 }
 
+declare class CBLValueIndexConfiguration extends CBLIndexConfiguration {
+
+	static alloc(): CBLValueIndexConfiguration; // inherited from NSObject
+
+	static new(): CBLValueIndexConfiguration; // inherited from NSObject
+
+	constructor(o: { expression: NSArray<string> | string[]; });
+
+	initWithExpression(expressions: NSArray<string> | string[]): this;
+}
+
 declare class CBLValueIndexItem extends NSObject {
 
 	static alloc(): CBLValueIndexItem; // inherited from NSObject
@@ -2519,3 +2623,13 @@ declare class CBLValueIndexItem extends NSObject {
 declare var CouchbaseLiteVersionNumber: number;
 
 declare var CouchbaseLiteVersionString: interop.Reference<number>;
+
+declare var kCBLBlobContentTypeProperty: string;
+
+declare var kCBLBlobDigestProperty: string;
+
+declare var kCBLBlobLengthProperty: string;
+
+declare var kCBLBlobType: string;
+
+declare var kCBLTypeProperty: string;


### PR DESCRIPTION
This update is needed mainly for iOS as cocoapods since `3.0.0` include arm64 and can be run on simulator.
See: https://github.com/triniwiz/nativescript-plugins/issues/106

I also tested `3.0.0` on android and there were no breaking changes.

Fixes #106 