### PR TITLE
fix(stripe) Add null safe operator

### DIFF
--- a/packages/nativescript-stripe/standard/index.ios.ts
+++ b/packages/nativescript-stripe/standard/index.ios.ts
@@ -212,7 +212,7 @@ class StripePaymentDelegate extends NSObject implements STPPaymentContextDelegat
 		StripeStandardConfig.shared.backendAPI
 			.capturePayment(paymentResult.paymentMethod.stripeId, paymentContext.paymentAmount, createShippingMethod(paymentContext), createAddress(paymentContext.shippingAddress))
 			.then((value: any) => {
-                if(!value._native.lastPaymentError || value._native.lastPaymentError == "undefined") {
+                if(!value._native?.lastPaymentError || value._native?.lastPaymentError == "undefined") {
                     completion(STPPaymentStatus.Success, null);
                     return
                 }


### PR DESCRIPTION
If capturePayment does not return a StripePaymentIntent, this will allow payments to succeed. Discussed in #141