### PR TITLE
[Stripe][Android] Handle 3DS cancellation/Failed authentication

### DIFF
--- a/packages/nativescript-stripe/standard/index.android.ts
+++ b/packages/nativescript-stripe/standard/index.android.ts
@@ -170,8 +170,8 @@ export class StripeStandardPaymentSession {
 				createAddress(data?.getShippingInformation())
 			)
 			.then((res: any) => {
-                // 3DS Failed/Cancelled Authentication
-                if(res?.status == "canceled") {
+                // 3DS Failed/Cancelled Authentication && if the use close the 3DS authentication window
+                if(res?.status == "canceled" || res?.native?.lastPaymentError != null) {
                     this.paymentInProgress = false;
                     this.listener.onUserCancelled();
                     return;


### PR DESCRIPTION
Hi @triniwiz :)

This plugin doesn't handle the `Failed/Canceled` `3DS` authentication, plus there was an casual issue with the card for failed payment ending with `0341` that doesn't have the `component1` when capturing the payment causing app crash.

There is it :)