### PR TITLE
[IOS] Handle Application delegate internally

### DIFF
--- a/packages/nativescript-star-ratings/README.md
+++ b/packages/nativescript-star-ratings/README.md
@@ -9,7 +9,20 @@ ns plugin add @triniwiz/nativescript-star-ratings
 
 [Documentation for the latest stable release](https://triniwiz.github.io/nativescript-plugins/api-reference/star-ratings.html)
 
+## API
 
+|Property | Default | Type | iOS | Android| Description
+|---|---|---|---|---|---|
+|emptyBorderColor |	blue |	string |	✅	| ❌|
+emptyColor|	white |	string	| ✅	 |✅|
+filledBorderColor |	blue|	string|	✅|	❌|
+filledColor|	white |	string|	✅|	✅|
+value|	0|	number|	✅|	✅|
+max |	5|	number|	✅|	✅|
+isindicator |	false|	boolean|	✅|	✅|
+updateOnTouch |	true|	boolean|	✅|	❌|IOS only, enable/disable user interaction
+starSize |	30|	number|	✅|	❌|
+starMargin |	5|	number|	✅|	❌|
 
 ## License
 

--- a/packages/nativescript-star-ratings/common.ts
+++ b/packages/nativescript-star-ratings/common.ts
@@ -9,12 +9,15 @@ export enum FillMode {
 export abstract class StarRatingBase extends View {
 	max: number;
 	value: number;
+    starSize: number;
+    starMargin: number;
 	fillMode: FillMode;
 	abstract emptyBorderColor: Color | string;
 	abstract filledBorderColor: Color | string;
 	abstract emptyColor: Color | string;
 	abstract filledColor: Color | string;
 	indicator: boolean;
+    updateOnTouch: boolean;
 }
 
 export const maxProperty = new Property<StarRatingBase, number>({
@@ -24,6 +27,14 @@ export const maxProperty = new Property<StarRatingBase, number>({
 export const valueProperty = new Property<StarRatingBase, number>({
 	name: 'value',
 	defaultValue: 1,
+});
+export const starSize = new Property({
+    name: 'starSize',
+    defaultValue: 20,
+});
+export const starMargin = new Property({
+    name: 'starMargin',
+    defaultValue: 5,
 });
 export const fillModeProperty = new Property<StarRatingBase, FillMode | 'full' | 'half' | 'precise'>({
 	name: 'fillMode',
@@ -50,7 +61,11 @@ export const indicatorProperty = new Property<StarRatingBase, boolean>({
 	defaultValue: false,
 	valueConverter: booleanConverter,
 });
-
+export const updateOnTouch = new Property({
+    name: 'updateOnTouch',
+    defaultValue: false,
+    valueConverter: booleanConverter,
+});
 declare module '@nativescript/core/ui/styling/style' {
 	interface Style {
 		emptyBorderColor: Color | string;
@@ -60,6 +75,9 @@ declare module '@nativescript/core/ui/styling/style' {
 	}
 }
 
+starSize.register(StarRatingBase);
+starMargin.register(StarRatingBase);
+updateOnTouch.register(StarRatingBase);
 indicatorProperty.register(StarRatingBase);
 fillModeProperty.register(StarRatingBase);
 emptyBorderColorProperty.register(Style);

--- a/packages/nativescript-star-ratings/index.ios.ts
+++ b/packages/nativescript-star-ratings/index.ios.ts
@@ -7,7 +7,8 @@ import {
   emptyColorProperty,
   filledColorProperty,
   fillModeProperty,
-  FillMode
+  FillMode,
+  starSize, starMargin, updateOnTouch 
 } from './common';
 import {Color} from '@nativescript/core';
 
@@ -25,6 +26,9 @@ export class StarRating extends StarRatingBase {
     nativeView.settings.filledColor = new Color('blue').ios;
     nativeView.rating = 0;
     nativeView.settings.minTouchRating = 0;
+    nativeView.settings.updateOnTouch = true;
+    nativeView.settings.starSize = 30;
+    nativeView.settings.starMargin = 5;
     return nativeView;
   }
 
@@ -37,6 +41,9 @@ export class StarRating extends StarRatingBase {
     this._handleMax(this.max);
     this._handleValue(this.value);
     this._handleFillMode(this.fillMode);
+    this._handleUpdateOnTouch(this.updateOnTouch);
+    this._handleSize(this.starSize);
+    this._handleMargin(this.starMargin);
   }
 
   public onLoaded() {
@@ -163,5 +170,29 @@ export class StarRating extends StarRatingBase {
 
   [maxProperty.setNative](max: number) {
     this._handleMax(max)
+  }
+  [starSize.setNative](value) {
+    this._handleSize(value);
+  }
+  _handleSize(value) {
+      if (this.nativeView) {
+          this.nativeView.settings.starSize = value;
+      }
+  }
+  [starMargin.setNative](value) {
+      this._handleMargin(value);
+  }
+  _handleMargin(value) {
+      if (this.nativeView) {
+          this.nativeView.settings.starMargin = value;
+      }
+  }
+  [updateOnTouch.setNative](value) {
+      this._handleUpdateOnTouch(value);
+  }
+  _handleUpdateOnTouch(value) {
+      if (this.nativeView) {
+          this.nativeView.settings.updateOnTouch = value;
+      }
   }
 }

--- a/packages/nativescript-stripe/standard/index.android.ts
+++ b/packages/nativescript-stripe/standard/index.android.ts
@@ -150,40 +150,42 @@ export class StripeStandardPaymentSession {
 	}
 
 	requestPayment() {
-		console.log('requestPayment')
-		this.paymentInProgress = true;
-		const data = this._data;
-		const shippingMethod = data.getShippingMethod();
-		const shippingCost = shippingMethod ? shippingMethod.getAmount() : 0;
-        const component1 = data.getPaymentMethod()?.component1();
-        if(!component1) {
-            console.log('Payment method undefined!');
-            this.listener.onError(500, 'Payment method undefined!');
-            this.paymentInProgress = false;
-            return
-        }
-		StripeStandardConfig.shared.backendAPI
-			.capturePayment(
-				component1, // id
-				data.getCartTotal() + shippingCost,
-				createShippingMethod(shippingMethod),
-				createAddress(data?.getShippingInformation())
-			)
-			.then((res: any) => {
-                // 3DS Failed/Cancelled Authentication && if the use close the 3DS authentication window
-                if(res?.status == "canceled" || res?.native?.lastPaymentError != null) {
-                    this.paymentInProgress = false;
-                    this.listener.onUserCancelled();
-                    return;
-                }
-				this.paymentInProgress = false;
-				this.listener.onPaymentSuccess();
-				this.native.onCompleted();
-			})
-			.catch((e) => {
-				this.listener.onError(100, e);
-				this.paymentInProgress = false;
-			});
+		 setTimeout(() => {
+      console.log('requestPayment')
+      this.paymentInProgress = true;
+      const data = this._data;
+      const shippingMethod = data?.getShippingMethod();
+      const shippingCost = shippingMethod ? shippingMethod.getAmount() : 0;
+          const component1 = data.getPaymentMethod()?.component1();
+          if(!component1) {
+              console.log('Payment method undefined!');
+              this.listener.onError(500, 'Payment method undefined!');
+              this.paymentInProgress = false;
+              return
+          }
+      StripeStandardConfig.shared.backendAPI
+        .capturePayment(
+          component1, // id
+          data.getCartTotal() + shippingCost,
+          createShippingMethod(shippingMethod),
+          createAddress(data?.getShippingInformation())
+        )
+        .then((res: any) => {
+                  // 3DS Failed/Cancelled Authentication && if the use close the 3DS authentication window
+                  if(res?.status == "canceled" || res?.native?.lastPaymentError != null) {
+                      this.paymentInProgress = false;
+                      this.listener.onUserCancelled();
+                      return;
+                  }
+          this.paymentInProgress = false;
+          this.listener.onPaymentSuccess();
+          this.native.onCompleted();
+        })
+        .catch((e) => {
+          this.listener.onError(100, e);
+          this.paymentInProgress = false;
+        });
+     })
 	}
 
 	presentPaymentMethods(): void {


### PR DESCRIPTION
Hi @triniwiz,

I add handling the Application delegate internally because I had a conflict between this plugin and `nativescript-community/universal-links` declaring a new delegate for Stripe return url causing the loose of the data for the univseral-link plugin, there was a work around to set the universal link from the new app delegate but I saw that will be useful as we don't need to handling the return url on the app side anymore and creating a delegation. Also this will be better approach to prevent conflict with other plugins.

PS: This solution is done by [nativescript-community](https://github.com/nativescript-community/universal-links/blob/master/src/universal-links/index.ios.ts)