### PR TITLE
bug: fix missing parenthesis in NativeClass decorator

### DIFF
--- a/packages/nativescript-image-zoom/index.ios.ts
+++ b/packages/nativescript-image-zoom/index.ios.ts
@@ -115,7 +115,7 @@ export class ImageZoom extends ImageZoomBase {
   }
 }
 
-@NativeClass
+@NativeClass()
 export class UIScrollViewDelegateImpl extends NSObject
   implements UIScrollViewDelegate {
   private owner: WeakRef<ImageZoom>;


### PR DESCRIPTION
Fixes https://github.com/triniwiz/nativescript-plugins/issues/88 🥂 