### PR TITLE
Fix [IOS] Payment Intent status

### DIFF
--- a/packages/nativescript-stripe/standard/index.ios.ts
+++ b/packages/nativescript-stripe/standard/index.ios.ts
@@ -242,7 +242,7 @@ class StripePaymentDelegate extends NSObject implements STPPaymentContextDelegat
                   break;
               case STPPaymentIntentStatus.STPPaymentIntentStatusCanceled:
               case STPPaymentIntentStatus.STPPaymentIntentStatusRequiresPaymentMethod:
-                  case STPPaymentIntentStatus.STPPaymentIntentStatusRequiresSourceAction:
+              case STPPaymentIntentStatus.STPPaymentIntentStatusRequiresSourceAction:
                   completion(STPPaymentStatus.UserCancellation, null);
                   break;
               case STPPaymentIntentStatus.STPPaymentIntentStatusSucceeded:


### PR DESCRIPTION
@triniwiz IOS return success when failed a 3DS payment.

I think this solution should be the same with android .. I have fixed this issue on android based on the paymentIntent status but I think it should be more complete such this way!


I am a little confused about those status, I think they will not be triggered on the payment process, for that I put them with the success
```ts
STPPaymentIntentStatusRequiresPaymentMethod
STPPaymentIntentStatusRequiresSource
STPPaymentIntentStatusRequiresSourceAction
```


What do you think ?