### PR TITLE
fix(couchbase): Method deleteDocument tries to delete null documents

### DIFF
--- a/packages/nativescript-couchbase/index.android.ts
+++ b/packages/nativescript-couchbase/index.android.ts
@@ -136,13 +136,16 @@ export class CouchBase extends Common {
 	}
 
 	deleteDocument(documentId: string, concurrencyMode: ConcurrencyMode = ConcurrencyMode.LastWriteWins) {
+		let success = false;
 		try {
 			const doc = this.android.getDocument(documentId);
-			return this.android.delete(doc, concurrencyMode === ConcurrencyMode.FailOnConflict ? com.couchbase.lite.ConcurrencyControl.FAIL_ON_CONFLICT : com.couchbase.lite.ConcurrencyControl.LAST_WRITE_WINS);
+			if (doc != null) {
+				success = this.android.delete(doc, concurrencyMode === ConcurrencyMode.FailOnConflict ? com.couchbase.lite.ConcurrencyControl.FAIL_ON_CONFLICT : com.couchbase.lite.ConcurrencyControl.LAST_WRITE_WINS);
+			}
 		} catch (e) {
 			console.error(e.message);
-			return false;
 		}
+		return success;
 	}
 
 	destroyDatabase() {

--- a/packages/nativescript-couchbase/index.ios.ts
+++ b/packages/nativescript-couchbase/index.ios.ts
@@ -398,8 +398,16 @@ export class CouchBase extends Common {
 	}
 
 	deleteDocument(documentId: string, concurrencyMode: ConcurrencyMode = 1) {
-		const doc = this.ios.documentWithID(documentId);
-		return this.ios.deleteDocumentConcurrencyControlError(doc, concurrencyMode === 1 ? CBLConcurrencyControl.kCBLConcurrencyControlFailOnConflict : CBLConcurrencyControl.kCBLConcurrencyControlLastWriteWins);
+		let success = false;
+		try {
+			const doc = this.ios.documentWithID(documentId);
+			if (doc != null) {
+				success = this.ios.deleteDocumentConcurrencyControlError(doc, concurrencyMode === 1 ? CBLConcurrencyControl.kCBLConcurrencyControlFailOnConflict : CBLConcurrencyControl.kCBLConcurrencyControlLastWriteWins);
+			}
+		} catch (e) {
+			console.error(e.message);
+		}
+		return success;
 	}
 
 	destroyDatabase() {


### PR DESCRIPTION
This ensures that method `deleteDocument` does not attempt to delete null instances and will return false in such a case.
This problem was more apparent on iOS as native call was not surrounded by try-catch.