### PR TITLE
feat(nativescript-sse): event listener support as in EventSource

### DIFF
--- a/packages/nativescript-sse/common.ts
+++ b/packages/nativescript-sse/common.ts
@@ -7,9 +7,9 @@ export abstract class BaseSSE {
     this.events = fromObject({});
   }
 
-  public abstract addEventListener(event: string): void;
+  public abstract addEventListener(event: string, handler: any): void;
 
-  public abstract removeEventListener(event: string): void;
+  public abstract removeEventListener(event: string, handler: any): void;
 
   public abstract connect(): void;
 

--- a/packages/nativescript-sse/index.android.ts
+++ b/packages/nativescript-sse/index.android.ts
@@ -8,32 +8,42 @@ export class SSE extends BaseSSE {
   private _es: any;
   private _headers: any;
   private _url: any;
+  private _eventListeners: any;
 
   constructor(url: string, headers: any = {}) {
     super(url, headers);
+    this._eventListeners = {};
     this._url = new java.net.URI(url);
     const that = new WeakRef(this);
     const EventHandler = com.tylerjroach.eventsource.EventSourceHandler.extend({
       owner: that.get(),
       onConnect() {
+        const eventObject = {
+          connected: true
+        };
         this.owner.events.notify({
           eventName: 'onConnect',
-          object: fromObject({
-            connected: true
-          })
+          object: fromObject(eventObject)
+        });
+        this.owner._eventListeners.open?.forEach((handler) => {
+          handler(eventObject);
         });
       },
       onMessage(event, message) {
+        const eventObject = {
+          event,
+          message: {
+            data: message.data,
+            lastEventId: message.lastEventId,
+            origin: message.origin
+          }
+        };
         this.owner.events.notify({
           eventName: 'onMessage',
-          object: fromObject({
-            event: event.toString(),
-            message: {
-              data: message.data,
-              lastEventId: message.lastEventId,
-              origin: message.origin
-            }
-          })
+          object: fromObject(eventObject)
+        });
+        this.owner._eventListeners[event]?.forEach((handler) => {
+          handler(eventObject);
         });
       },
 
@@ -47,19 +57,27 @@ export class SSE extends BaseSSE {
       },
 
       onError(e) {
+        const eventObject = {
+          error: e.getMessage()
+        };
         this.owner.events.notify({
           eventName: 'onError',
-          object: fromObject({
-            error: e.getMessage()
-          })
+          object: fromObject(eventObject)
+        });
+        this.owner._eventListeners.error?.forEach((handler) => {
+          handler(eventObject);
         });
       },
       onClosed(willReconnect) {
+        const eventObject = {
+          willReconnect
+        };
         this.owner.events.notify({
           eventName: 'willReconnect',
-          object: fromObject({
-            willReconnect: willReconnect
-          })
+          object: fromObject(eventObject)
+        });
+        this.owner._eventListeners.close?.forEach((handler) => {
+          handler(eventObject);
         });
       }
     });
@@ -79,10 +97,17 @@ export class SSE extends BaseSSE {
     this._es.connect();
   }
 
-  public addEventListener(event: string): void {
+  public addEventListener(event: string, handler: any): void {
+    if (this._eventListeners[event] === undefined) {
+        this._eventListeners[event] = [];
+    }
+    this._eventListeners[event].push(handler)
   }
 
-  public removeEventListener(event: string): void {
+  public removeEventListener(event: string, handler: any): void {
+    if (this._eventListeners[event] !== undefined) {
+      this._eventListeners[event] = this._eventListeners[event].filter(h => h !== handler);
+    }
   }
 
   public connect(): void {


### PR DESCRIPTION
Hello @triniwiz, we would like to use your @triniwiz/nativescript-sse plugin (that is not released yet) as an EventSource counterpart in our app. To achieve this we made these changes.

- `addEventListener`, and `removeEventListener` methods were empty in the "index.android.ts". they had some code in "index.ios.ts" but it was just to handle custom events and trigger `onMessage`. there is no need to do anything on android to get these custom events as they trigger onMessage automatically.
It was not possible to attach event handlers on both platforms; listener methods didn't contain a parameter to pass a handler.
`_eventListeners` object is added to store the added listeners' handlers by event name. `addEventListener`, and `removeEventListener` methods are updated to be used for managing the listeners for custom, or standard events (open, close, error, message). And now the plugin will call the added listeners' handlers when a relevant event is received as in the EventSource.

- `removeEventListener` was suspending (stop calling `onMessage` when a custom event is received) the event completely (on iOS) which called for. now it only suspends when all the event listeners are removed for that event.

- `this._es.onCompleteBridged` replaced by `this._es.onComplete` on "index.ios.ts" to fix (TypeError: this._es.onCompleteBridged is not a function)