### PR TITLE
feat(supabase): update gotrue, persist offline session

### DIFF
--- a/packages/nativescript-supabase-gotrue/AuthAdminApi.ts
+++ b/packages/nativescript-supabase-gotrue/AuthAdminApi.ts
@@ -1,0 +1,5 @@
+import GoTrueAdminApi from './GoTrueAdminApi'
+
+const AuthAdminApi = GoTrueAdminApi
+
+export default AuthAdminApi

--- a/packages/nativescript-supabase-gotrue/AuthClient.ts
+++ b/packages/nativescript-supabase-gotrue/AuthClient.ts
@@ -1,0 +1,5 @@
+import GoTrueClient from './GoTrueClient'
+
+const AuthClient = GoTrueClient
+
+export default AuthClient

--- a/packages/nativescript-supabase-gotrue/GoTrueAdminApi.ts
+++ b/packages/nativescript-supabase-gotrue/GoTrueAdminApi.ts
@@ -36,10 +36,11 @@ export default class GoTrueAdminApi {
 	/**
 	 * Removes a logged-in session.
 	 * @param jwt A valid, logged-in JWT.
+	 * @param scope The logout sope.
 	 */
-	async signOut(jwt: string): Promise<{ data: null; error: AuthError | null }> {
+	async signOut(jwt: string, scope: 'global' | 'local' | 'others' = 'global'): Promise<{ data: null; error: AuthError | null }> {
 		try {
-			await _request(this.fetch, 'POST', `${this.url}/logout`, {
+			await _request(this.fetch, 'POST', `${this.url}/logout?scope=${scope}`, {
 				headers: this.headers,
 				jwt,
 				noResolveJson: true,
@@ -57,14 +58,16 @@ export default class GoTrueAdminApi {
 	/**
 	 * Sends an invite link to an email address.
 	 * @param email The email address of the user.
-	 * @param options.redirectTo A URL or mobile deeplink to send the user to after they are confirmed.
-	 * @param options.data Optional user metadata
+	 * @param options Additional options to be included when inviting.
 	 */
 	async inviteUserByEmail(
 		email: string,
 		options: {
-			redirectTo?: string;
+			/** A custom data object to store additional metadata about the user. This maps to the `auth.users.user_metadata` column. */
 			data?: object;
+
+			/** The URL which will be appended to the email link sent to the user's email address. Once clicked the user will end up on this URL. */
+			redirectTo?: string;
 		} = {}
 	): Promise<UserResponse> {
 		try {
@@ -230,7 +233,7 @@ export default class GoTrueAdminApi {
 	 * Delete a user. Requires a `service_role` key.
 	 *
 	 * @param id The user id you want to remove.
-	 * @param shouldSoftDelete If true, then the user will be soft-deleted from the auth schema.
+	 * @param shouldSoftDelete If true, then the user will be soft-deleted (setting `deleted_at` to the current timestamp and disabling their account while preserving their data) from the auth schema.
 	 * Defaults to false for backward compatibility.
 	 *
 	 * This function should only be called on a server. Never expose your `service_role` key in the browser.

--- a/packages/nativescript-supabase-gotrue/GoTrueClient.ts
+++ b/packages/nativescript-supabase-gotrue/GoTrueClient.ts
@@ -1,13 +1,20 @@
 import GoTrueAdminApi from './GoTrueAdminApi';
 import { DEFAULT_HEADERS, EXPIRY_MARGIN, GOTRUE_URL, STORAGE_KEY } from './lib/constants';
-import { AuthError, AuthImplicitGrantRedirectError, AuthPKCEGrantCodeExchangeError, AuthInvalidCredentialsError, AuthRetryableFetchError, AuthSessionMissingError, AuthUnknownError, isAuthApiError, isAuthError } from './lib/errors';
-import { Fetch, _request, _sessionResponse, _userResponse, _ssoResponse } from './lib/fetch';
-import { decodeJWTPayload, Deferred, getItemAsync, getParameterByName, isBrowser, removeItemAsync, resolveFetch, setItemAsync, uuid, retryable, sleep, generatePKCEVerifier, generatePKCEChallenge } from './lib/helpers';
-import localStorageAdapter from './lib/local-storage';
+import { AuthError, AuthImplicitGrantRedirectError, AuthPKCEGrantCodeExchangeError, AuthInvalidCredentialsError, AuthSessionMissingError, AuthInvalidTokenResponseError, AuthUnknownError, isAuthApiError, isAuthError, isAuthRetryableFetchError } from './lib/errors';
+import { Fetch, _request, _sessionResponse, _sessionResponsePassword, _userResponse, _ssoResponse } from './lib/fetch';
+import { decodeJWTPayload, Deferred, getItemAsync, isBrowser, removeItemAsync, resolveFetch, setItemAsync, uuid, retryable, sleep, generatePKCEVerifier, generatePKCEChallenge, supportsLocalStorage, parseParametersFromURL } from './lib/helpers';
+import { localStorageAdapter, memoryLocalStorageAdapter } from './lib/local-storage';
+import { version } from './lib/version';
+// import { polyfillGlobalThis } from './lib/polyfills';
+// import { LockAcquireTimeoutError, navigatorLock } from './lib/locks';
 
 import type {
 	AuthChangeEvent,
 	AuthResponse,
+	AuthResponsePassword,
+	AuthTokenResponse,
+	AuthTokenResponsePassword,
+	AuthOtpResponse,
 	CallRefreshTokenResult,
 	GoTrueClientOptions,
 	InitializeResult,
@@ -21,6 +28,7 @@ import type {
 	SignInWithPasswordlessCredentials,
 	SignUpWithPasswordCredentials,
 	SignInWithSSO,
+	SignOut,
 	Subscription,
 	SupportedStorage,
 	User,
@@ -42,10 +50,16 @@ import type {
 	AuthenticatorAssuranceLevels,
 	Factor,
 	MFAChallengeAndVerifyParams,
+	ResendParams,
 	AuthFlowType,
+	LockFunc,
+	UserIdentity,
+	WeakPassword,
 } from './lib/types';
 
-const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage'> = {
+// polyfillGlobalThis(); // Make "globalThis" available
+
+const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage' | 'lock'> = {
 	url: GOTRUE_URL,
 	storageKey: STORAGE_KEY,
 	autoRefreshToken: true,
@@ -53,6 +67,7 @@ const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage'> 
 	detectSessionInUrl: true,
 	headers: DEFAULT_HEADERS,
 	flowType: 'implicit',
+	debug: false,
 };
 
 /** Current session will be checked for refresh at this interval. */
@@ -62,7 +77,15 @@ const AUTO_REFRESH_TICK_DURATION = 10 * 1000;
  * A token refresh will be attempted this many ticks before the current session expires. */
 const AUTO_REFRESH_TICK_THRESHOLD = 3;
 
+async function lockNoOp<R>(name: string, acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
+	return await fn();
+}
+
 export default class GoTrueClient {
+	private static nextInstanceID = 0;
+
+	private instanceID: number;
+
 	/**
 	 * Namespace for the GoTrue admin methods.
 	 * These methods should only be used in a trusted server-side environment.
@@ -77,17 +100,12 @@ export default class GoTrueClient {
 	 */
 	protected storageKey: string;
 
-	/**
-	 * The session object for the currently logged in user. If null, it means there isn't a logged-in user.
-	 * Only used if persistSession is false.
-	 */
-	protected inMemorySession: Session | null;
-
 	protected flowType: AuthFlowType;
 
 	protected autoRefreshToken: boolean;
 	protected persistSession: boolean;
 	protected storage: SupportedStorage;
+	protected memoryStorage: { [key: string]: string } | null = null;
 	protected stateChangeEmitters: Map<string, Subscription> = new Map();
 	protected autoRefreshTicker: ReturnType<typeof setInterval> | null = null;
 	protected visibilityChangedCallback: (() => Promise<any>) | null = null;
@@ -105,6 +123,9 @@ export default class GoTrueClient {
 		[key: string]: string;
 	};
 	protected fetch: Fetch;
+	protected lock: LockFunc;
+	protected lockAcquired = false;
+	protected pendingInLock: Promise<any>[] = [];
 
 	/**
 	 * Used to broadcast state change events to other tabs listening.
@@ -112,16 +133,30 @@ export default class GoTrueClient {
 	 */
 	protected broadcastChannel: BroadcastChannel | null = null;
 
+	protected logDebugMessages: boolean;
+	protected logger: (message: string, ...args: any[]) => void = console.log;
+
 	/**
 	 * Create a new client for use in the browser.
 	 */
 	constructor(options: GoTrueClientOptions) {
+		this.instanceID = GoTrueClient.nextInstanceID;
+		GoTrueClient.nextInstanceID += 1;
+
+		if (this.instanceID > 0 && isBrowser()) {
+			console.warn('Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.');
+		}
+
 		const settings = { ...DEFAULT_OPTIONS, ...options };
-		this.inMemorySession = null;
+
+		this.logDebugMessages = !!settings.debug;
+		if (typeof settings.debug === 'function') {
+			this.logger = settings.debug;
+		}
+
+		this.persistSession = settings.persistSession;
 		this.storageKey = settings.storageKey;
 		this.autoRefreshToken = settings.autoRefreshToken;
-		this.persistSession = settings.persistSession;
-		this.storage = settings.storage || localStorageAdapter;
 		this.admin = new GoTrueAdminApi({
 			url: settings.url,
 			headers: settings.headers,
@@ -131,8 +166,18 @@ export default class GoTrueClient {
 		this.url = settings.url;
 		this.headers = settings.headers;
 		this.fetch = resolveFetch(settings.fetch);
+		this.lock = settings.lock || lockNoOp;
 		this.detectSessionInUrl = settings.detectSessionInUrl;
 		this.flowType = settings.flowType;
+
+		if (settings.lock) {
+			this.lock = settings.lock;
+			// custom: don't use navigatorLock in NativeScript
+			// } else if (isBrowser() && globalThis?.navigator?.locks) {
+			// 	this.lock = navigatorLock;
+		} else {
+			this.lock = lockNoOp;
+		}
 
 		this.mfa = {
 			verify: this._verify.bind(this),
@@ -144,7 +189,45 @@ export default class GoTrueClient {
 			getAuthenticatorAssuranceLevel: this._getAuthenticatorAssuranceLevel.bind(this),
 		};
 
+		if (this.persistSession) {
+			if (settings.storage) {
+				this.storage = settings.storage;
+			} else {
+				if (supportsLocalStorage()) {
+					this.storage = localStorageAdapter;
+				} else {
+					this.memoryStorage = {};
+					this.storage = memoryLocalStorageAdapter(this.memoryStorage);
+				}
+			}
+		} else {
+			this.memoryStorage = {};
+			this.storage = memoryLocalStorageAdapter(this.memoryStorage);
+		}
+
+		if (isBrowser() && globalThis.BroadcastChannel && this.persistSession && this.storageKey) {
+			try {
+				this.broadcastChannel = new globalThis.BroadcastChannel(this.storageKey);
+			} catch (e: any) {
+				console.error('Failed to create a new BroadcastChannel, multi-tab state changes will not be available', e);
+			}
+
+			this.broadcastChannel?.addEventListener('message', async (event) => {
+				this._debug('received broadcast notification from other tab or client', event);
+
+				await this._notifyAllSubscribers(event.data.event, event.data.session, false); // broadcast = false so we don't get an endless loop of messages
+			});
+		}
+
 		this.initialize();
+	}
+
+	private _debug(...args: any[]): GoTrueClient {
+		if (this.logDebugMessages) {
+			this.logger(`GoTrueClient@${this.instanceID} (${version}) ${new Date().toISOString()}`, ...args);
+		}
+
+		return this;
 	}
 
 	/**
@@ -152,12 +235,18 @@ export default class GoTrueClient {
 	 * This method is automatically called when instantiating the client, but should also be called
 	 * manually when checking for an error from an auth redirect (oauth, magiclink, password recovery, etc).
 	 */
-	initialize(): Promise<InitializeResult> {
-		if (!this.initializePromise) {
-			this.initializePromise = this._initialize();
+	async initialize(): Promise<InitializeResult> {
+		if (this.initializePromise) {
+			return await this.initializePromise;
 		}
 
-		return this.initializePromise;
+		this.initializePromise = (async () => {
+			return await this._acquireLock(-1, async () => {
+				return await this._initialize();
+			});
+		})();
+
+		return await this.initializePromise;
 	}
 
 	/**
@@ -167,15 +256,21 @@ export default class GoTrueClient {
 	 *    the whole lifetime of the client
 	 */
 	private async _initialize(): Promise<InitializeResult> {
-		if (this.initializePromise) {
-			return this.initializePromise;
-		}
-
 		try {
-			const isPKCEFlow = await this._isPKCEFlow();
-			if ((this.detectSessionInUrl && this._isImplicitGrantFlow()) || isPKCEFlow) {
-				const { data, error } = await this._getSessionFromUrl(isPKCEFlow);
+			const isPKCEFlow = isBrowser() ? await this._isPKCEFlow() : false;
+			this._debug('#_initialize()', 'begin', 'is PKCE flow', isPKCEFlow);
+
+			if (isPKCEFlow || (this.detectSessionInUrl && this._isImplicitGrantFlow())) {
+				const { data, error } = await this._getSessionFromURL(isPKCEFlow);
 				if (error) {
+					this._debug('#_initialize()', 'error detecting session from URL', error);
+
+					// hacky workaround to keep the existing session if there's an error returned from identity linking
+					// TODO: once error codes are ready, we should match against it instead of the message
+					if (error?.message === 'Identity is already linked' || error?.message === 'Identity is already linked to another user') {
+						return { error };
+					}
+
 					// failed login attempt via url,
 					// remove old session as in verifyOtp, signUp and signInWith*
 					await this._removeSession();
@@ -185,19 +280,20 @@ export default class GoTrueClient {
 
 				const { session, redirectType } = data;
 
+				this._debug('#_initialize()', 'detected session in URL', session, 'redirect type', redirectType);
+
 				await this._saveSession(session);
 
-				setTimeout(() => {
+				setTimeout(async () => {
 					if (redirectType === 'recovery') {
-						this._notifyAllSubscribers('PASSWORD_RECOVERY', session);
+						await this._notifyAllSubscribers('PASSWORD_RECOVERY', session);
 					} else {
-						this._notifyAllSubscribers('SIGNED_IN', session);
+						await this._notifyAllSubscribers('SIGNED_IN', session);
 					}
 				}, 0);
 
 				return { error: null };
 			}
-
 			// no login attempt via callback url try to recover session from storage
 			await this._recoverAndRefresh();
 			return { error: null };
@@ -211,6 +307,7 @@ export default class GoTrueClient {
 			};
 		} finally {
 			await this._handleVisibilityChange();
+			this._debug('#_initialize()', 'end');
 		}
 	}
 
@@ -219,6 +316,7 @@ export default class GoTrueClient {
 	 *
 	 * Be aware that if a user account exists in the system you may get back an
 	 * error message that attempts to hide this information from the user.
+	 * This method has support for PKCE via email signups. The PKCE flow cannot be used when autoconfirm is enabled.
 	 *
 	 * @returns A logged-in session if the server has "autoconfirm" ON
 	 * @returns A user if the server has "autoconfirm" OFF
@@ -230,6 +328,14 @@ export default class GoTrueClient {
 			let res: AuthResponse;
 			if ('email' in credentials) {
 				const { email, password, options } = credentials;
+				let codeChallenge: string | null = null;
+				let codeChallengeMethod: string | null = null;
+				if (this.flowType === 'pkce') {
+					const codeVerifier = generatePKCEVerifier();
+					await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
+					codeChallenge = await generatePKCEChallenge(codeVerifier);
+					codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
+				}
 				res = await _request(this.fetch, 'POST', `${this.url}/signup`, {
 					headers: this.headers,
 					redirectTo: options?.emailRedirectTo,
@@ -238,6 +344,8 @@ export default class GoTrueClient {
 						password,
 						data: options?.data ?? {},
 						gotrue_meta_security: { captcha_token: options?.captchaToken },
+						code_challenge: codeChallenge,
+						code_challenge_method: codeChallengeMethod,
 					},
 					xform: _sessionResponse,
 				});
@@ -269,7 +377,7 @@ export default class GoTrueClient {
 
 			if (data.session) {
 				await this._saveSession(data.session);
-				this._notifyAllSubscribers('SIGNED_IN', session);
+				await this._notifyAllSubscribers('SIGNED_IN', session);
 			}
 
 			return { data: { user, session }, error: null };
@@ -290,11 +398,11 @@ export default class GoTrueClient {
 	 * email/phone and password combination is wrong or that the account can only
 	 * be accessed via social login.
 	 */
-	async signInWithPassword(credentials: SignInWithPasswordCredentials): Promise<AuthResponse> {
+	async signInWithPassword(credentials: SignInWithPasswordCredentials): Promise<AuthTokenResponsePassword> {
 		try {
 			await this._removeSession();
 
-			let res: AuthResponse;
+			let res: AuthResponsePassword;
 			if ('email' in credentials) {
 				const { email, password, options } = credentials;
 				res = await _request(this.fetch, 'POST', `${this.url}/token?grant_type=password`, {
@@ -304,7 +412,7 @@ export default class GoTrueClient {
 						password,
 						gotrue_meta_security: { captcha_token: options?.captchaToken },
 					},
-					xform: _sessionResponse,
+					xform: _sessionResponsePassword,
 				});
 			} else if ('phone' in credentials) {
 				const { phone, password, options } = credentials;
@@ -315,18 +423,30 @@ export default class GoTrueClient {
 						password,
 						gotrue_meta_security: { captcha_token: options?.captchaToken },
 					},
-					xform: _sessionResponse,
+					xform: _sessionResponsePassword,
 				});
 			} else {
 				throw new AuthInvalidCredentialsError('You must provide either an email or phone number and a password');
 			}
 			const { data, error } = res;
-			if (error || !data) return { data: { user: null, session: null }, error };
+
+			if (error) {
+				return { data: { user: null, session: null }, error };
+			} else if (!data || !data.session || !data.user) {
+				return { data: { user: null, session: null }, error: new AuthInvalidTokenResponseError() };
+			}
 			if (data.session) {
 				await this._saveSession(data.session);
-				this._notifyAllSubscribers('SIGNED_IN', data.session);
+				await this._notifyAllSubscribers('SIGNED_IN', data.session);
 			}
-			return { data, error } as any;
+			return {
+				data: {
+					user: data.user,
+					session: data.session,
+					...('weak_password' in data ? { weakPassword: data.weak_password } : null),
+				},
+				error,
+			} as any;
 		} catch (error) {
 			if (isAuthError(error)) {
 				return { data: { user: null, session: null }, error };
@@ -337,6 +457,7 @@ export default class GoTrueClient {
 
 	/**
 	 * Log in an existing user via a third-party provider.
+	 * This method supports the PKCE flow.
 	 */
 	async signInWithOAuth(credentials: SignInWithOAuthCredentials): Promise<OAuthResponse> {
 		await this._removeSession();
@@ -350,10 +471,25 @@ export default class GoTrueClient {
 	}
 
 	/**
-	 * Log in an existing user via a third-party provider.
+	 * Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
 	 */
-	async exchangeCodeForSession(authCode: string): Promise<AuthResponse> {
-		const codeVerifier = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`);
+	async exchangeCodeForSession(authCode: string): Promise<AuthTokenResponse> {
+		await this.initializePromise;
+
+		return this._acquireLock(-1, async () => {
+			return this._exchangeCodeForSession(authCode);
+		});
+	}
+
+	private async _exchangeCodeForSession(authCode: string): Promise<
+		| {
+				data: { session: Session; user: User; redirectType: string | null };
+				error: null;
+		  }
+		| { data: { session: null; user: null; redirectType: null }; error: AuthError }
+	> {
+		const storageItem = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`);
+		const [codeVerifier, redirectType] = ((storageItem ?? '') as string).split('/');
 		const { data, error } = await _request(this.fetch, 'POST', `${this.url}/token?grant_type=pkce`, {
 			headers: this.headers,
 			body: {
@@ -363,31 +499,37 @@ export default class GoTrueClient {
 			xform: _sessionResponse,
 		});
 		await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`);
-		if (error || !data) return { data: { user: null, session: null }, error };
+		if (error) {
+			return { data: { user: null, session: null, redirectType: null }, error };
+		} else if (!data || !data.session || !data.user) {
+			return {
+				data: { user: null, session: null, redirectType: null },
+				error: new AuthInvalidTokenResponseError(),
+			};
+		}
 		if (data.session) {
 			await this._saveSession(data.session);
-			this._notifyAllSubscribers('SIGNED_IN', data.session);
+			await this._notifyAllSubscribers('SIGNED_IN', data.session);
 		}
-		return { data, error };
+		return { data: { ...data, redirectType: redirectType ?? null }, error };
 	}
 
 	/**
-	 * Allows signing in with an ID token issued by certain supported providers.
-	 * The ID token is verified for validity and a new session is established.
-	 *
-	 * @experimental
+	 * Allows signing in with an OIDC ID token. The authentication provider used
+	 * should be enabled and configured.
 	 */
-	async signInWithIdToken(credentials: SignInWithIdTokenCredentials): Promise<AuthResponse> {
+	async signInWithIdToken(credentials: SignInWithIdTokenCredentials): Promise<AuthTokenResponse> {
 		await this._removeSession();
 
 		try {
-			const { options, provider, token, nonce } = credentials;
+			const { options, provider, token, access_token, nonce } = credentials;
 
 			const res = await _request(this.fetch, 'POST', `${this.url}/token?grant_type=id_token`, {
 				headers: this.headers,
 				body: {
 					provider,
 					id_token: token,
+					access_token,
 					nonce,
 					gotrue_meta_security: { captcha_token: options?.captchaToken },
 				},
@@ -395,10 +537,17 @@ export default class GoTrueClient {
 			});
 
 			const { data, error } = res;
-			if (error || !data) return { data: { user: null, session: null }, error };
+			if (error) {
+				return { data: { user: null, session: null }, error };
+			} else if (!data || !data.session || !data.user) {
+				return {
+					data: { user: null, session: null },
+					error: new AuthInvalidTokenResponseError(),
+				};
+			}
 			if (data.session) {
 				await this._saveSession(data.session);
-				this._notifyAllSubscribers('SIGNED_IN', data.session);
+				await this._notifyAllSubscribers('SIGNED_IN', data.session);
 			}
 			return { data, error };
 		} catch (error) {
@@ -424,18 +573,21 @@ export default class GoTrueClient {
 	 * if you are using phone sign in with the 'whatsapp' channel. The whatsapp
 	 * channel is not supported on other providers
 	 * at this time.
+	 * This method supports PKCE when an email is passed.
 	 */
-	async signInWithOtp(credentials: SignInWithPasswordlessCredentials): Promise<AuthResponse> {
+	async signInWithOtp(credentials: SignInWithPasswordlessCredentials): Promise<AuthOtpResponse> {
 		try {
 			await this._removeSession();
 
 			if ('email' in credentials) {
 				const { email, options } = credentials;
 				let codeChallenge: string | null = null;
+				let codeChallengeMethod: string | null = null;
 				if (this.flowType === 'pkce') {
 					const codeVerifier = generatePKCEVerifier();
 					await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
 					codeChallenge = await generatePKCEChallenge(codeVerifier);
+					codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
 				}
 				const { error } = await _request(this.fetch, 'POST', `${this.url}/otp`, {
 					headers: this.headers,
@@ -445,7 +597,7 @@ export default class GoTrueClient {
 						create_user: options?.shouldCreateUser ?? true,
 						gotrue_meta_security: { captcha_token: options?.captchaToken },
 						code_challenge: codeChallenge,
-						code_challenge_method: codeChallenge ? 's256' : null,
+						code_challenge_method: codeChallengeMethod,
 					},
 					redirectTo: options?.emailRedirectTo,
 				});
@@ -453,7 +605,7 @@ export default class GoTrueClient {
 			}
 			if ('phone' in credentials) {
 				const { phone, options } = credentials;
-				const { error } = await _request(this.fetch, 'POST', `${this.url}/otp`, {
+				const { data, error } = await _request(this.fetch, 'POST', `${this.url}/otp`, {
 					headers: this.headers,
 					body: {
 						phone,
@@ -463,7 +615,7 @@ export default class GoTrueClient {
 						channel: options?.channel ?? 'sms',
 					},
 				});
-				return { data: { user: null, session: null }, error };
+				return { data: { user: null, session: null, messageId: data?.message_id }, error };
 			}
 			throw new AuthInvalidCredentialsError('You must provide either an email or phone number.');
 		} catch (error) {
@@ -476,18 +628,28 @@ export default class GoTrueClient {
 	}
 
 	/**
-	 * Log in a user given a User supplied OTP received via mobile.
+	 * Log in a user given a User supplied OTP or TokenHash received through mobile or email.
 	 */
 	async verifyOtp(params: VerifyOtpParams): Promise<AuthResponse> {
 		try {
-			await this._removeSession();
+			if (params.type !== 'email_change' && params.type !== 'phone_change') {
+				// we don't want to remove the authenticated session if the user is performing an email_change or phone_change verification
+				await this._removeSession();
+			}
+
+			let redirectTo = undefined;
+			let captchaToken = undefined;
+			if ('options' in params) {
+				redirectTo = params.options?.redirectTo;
+				captchaToken = params.options?.captchaToken;
+			}
 			const { data, error } = await _request(this.fetch, 'POST', `${this.url}/verify`, {
 				headers: this.headers,
 				body: {
 					...params,
-					gotrue_meta_security: { captcha_token: params.options?.captchaToken },
+					gotrue_meta_security: { captcha_token: captchaToken },
 				},
-				redirectTo: params.options?.redirectTo,
+				redirectTo,
 				xform: _sessionResponse,
 			});
 
@@ -504,7 +666,7 @@ export default class GoTrueClient {
 
 			if (session?.access_token) {
 				await this._saveSession(session as Session);
-				this._notifyAllSubscribers('SIGNED_IN', session);
+				await this._notifyAllSubscribers(params.type == 'recovery' ? 'PASSWORD_RECOVERY' : 'SIGNED_IN', session);
 			}
 
 			return { data: { user, session }, error: null };
@@ -534,6 +696,14 @@ export default class GoTrueClient {
 	async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
 		try {
 			await this._removeSession();
+			let codeChallenge: string | null = null;
+			let codeChallengeMethod: string | null = null;
+			if (this.flowType === 'pkce') {
+				const codeVerifier = generatePKCEVerifier();
+				await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
+				codeChallenge = await generatePKCEChallenge(codeVerifier);
+				codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
+			}
 
 			return await _request(this.fetch, 'POST', `${this.url}/sso`, {
 				body: {
@@ -542,6 +712,8 @@ export default class GoTrueClient {
 					redirect_to: params.options?.redirectTo ?? undefined,
 					...(params?.options?.captchaToken ? { gotrue_meta_security: { captcha_token: params.options.captchaToken } } : null),
 					skip_http_redirect: true, // fetch does not handle redirects
+					code_challenge: codeChallenge,
+					code_challenge_method: codeChallengeMethod,
 				},
 				headers: this.headers,
 				xform: _ssoResponse,
@@ -555,10 +727,214 @@ export default class GoTrueClient {
 	}
 
 	/**
+	 * Sends a reauthentication OTP to the user's email or phone number.
+	 * Requires the user to be signed-in.
+	 */
+	async reauthenticate(): Promise<AuthResponse> {
+		await this.initializePromise;
+
+		return await this._acquireLock(-1, async () => {
+			return await this._reauthenticate();
+		});
+	}
+
+	private async _reauthenticate(): Promise<AuthResponse> {
+		try {
+			return await this._useSession(async (result) => {
+				const {
+					data: { session },
+					error: sessionError,
+				} = result;
+				if (sessionError) throw sessionError;
+				if (!session) throw new AuthSessionMissingError();
+
+				const { error } = await _request(this.fetch, 'GET', `${this.url}/reauthenticate`, {
+					headers: this.headers,
+					jwt: session.access_token,
+				});
+				return { data: { user: null, session: null }, error };
+			});
+		} catch (error) {
+			if (isAuthError(error)) {
+				return { data: { user: null, session: null }, error };
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
+	 */
+	async resend(credentials: ResendParams): Promise<AuthOtpResponse> {
+		try {
+			if (credentials.type != 'email_change' && credentials.type != 'phone_change') {
+				await this._removeSession();
+			}
+
+			const endpoint = `${this.url}/resend`;
+			if ('email' in credentials) {
+				const { email, type, options } = credentials;
+				const { error } = await _request(this.fetch, 'POST', endpoint, {
+					headers: this.headers,
+					body: {
+						email,
+						type,
+						gotrue_meta_security: { captcha_token: options?.captchaToken },
+					},
+					redirectTo: options?.emailRedirectTo,
+				});
+				return { data: { user: null, session: null }, error };
+			} else if ('phone' in credentials) {
+				const { phone, type, options } = credentials;
+				const { data, error } = await _request(this.fetch, 'POST', endpoint, {
+					headers: this.headers,
+					body: {
+						phone,
+						type,
+						gotrue_meta_security: { captcha_token: options?.captchaToken },
+					},
+				});
+				return { data: { user: null, session: null, messageId: data?.message_id }, error };
+			}
+			throw new AuthInvalidCredentialsError('You must provide either an email or phone number and a type');
+		} catch (error) {
+			if (isAuthError(error)) {
+				return { data: { user: null, session: null }, error };
+			}
+			throw error;
+		}
+	}
+
+	/**
 	 * Returns the session, refreshing it if necessary.
 	 * The session returned can be null if the session is not detected which can happen in the event a user is not signed-in or has logged out.
 	 */
-	async getSession(): Promise<
+	async getSession() {
+		await this.initializePromise;
+
+		return this._acquireLock(-1, async () => {
+			return this._useSession(async (result) => {
+				return result;
+			});
+		});
+	}
+
+	/**
+	 * Acquires a global lock based on the storage key.
+	 */
+	private async _acquireLock<R>(acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
+		this._debug('#_acquireLock', 'begin', acquireTimeout);
+
+		try {
+			if (this.lockAcquired) {
+				const last = this.pendingInLock.length ? this.pendingInLock[this.pendingInLock.length - 1] : Promise.resolve();
+
+				const result = (async () => {
+					await last;
+					return await fn();
+				})();
+
+				this.pendingInLock.push(
+					(async () => {
+						try {
+							await result;
+						} catch (e: any) {
+							// we just care if it finished
+						}
+					})()
+				);
+
+				return result;
+			}
+
+			return await this.lock(`lock:${this.storageKey}`, acquireTimeout, async () => {
+				this._debug('#_acquireLock', 'lock acquired for storage key', this.storageKey);
+
+				try {
+					this.lockAcquired = true;
+
+					const result = fn();
+
+					this.pendingInLock.push(
+						(async () => {
+							try {
+								await result;
+							} catch (e: any) {
+								// we just care if it finished
+							}
+						})()
+					);
+
+					await result;
+
+					// keep draining the queue until there's nothing to wait on
+					while (this.pendingInLock.length) {
+						const waitOn = [...this.pendingInLock];
+
+						await Promise.all(waitOn);
+
+						this.pendingInLock.splice(0, waitOn.length);
+					}
+
+					return await result;
+				} finally {
+					this._debug('#_acquireLock', 'lock released for storage key', this.storageKey);
+
+					this.lockAcquired = false;
+				}
+			});
+		} finally {
+			this._debug('#_acquireLock', 'end');
+		}
+	}
+
+	/**
+	 * Use instead of {@link #getSession} inside the library. It is
+	 * semantically usually what you want, as getting a session involves some
+	 * processing afterwards that requires only one client operating on the
+	 * session at once across multiple tabs or processes.
+	 */
+	private async _useSession<R>(
+		fn: (
+			result:
+				| {
+						data: {
+							session: Session;
+						};
+						error: null;
+				  }
+				| {
+						data: {
+							session: null;
+						};
+						error: AuthError;
+				  }
+				| {
+						data: {
+							session: null;
+						};
+						error: null;
+				  }
+		) => Promise<R>
+	): Promise<R> {
+		this._debug('#_useSession', 'begin');
+
+		try {
+			// the use of __loadSession here is the only correct use of the function!
+			const result = await this.__loadSession();
+
+			return await fn(result);
+		} finally {
+			this._debug('#_useSession', 'end');
+		}
+	}
+
+	/**
+	 * NEVER USE DIRECTLY!
+	 *
+	 * Always use {@link #_useSession}.
+	 */
+	private async __loadSession(): Promise<
 		| {
 				data: {
 					session: Session;
@@ -578,41 +954,56 @@ export default class GoTrueClient {
 				error: null;
 		  }
 	> {
-		// make sure we've read the session from the url if there is one
-		// save to just await, as long we make sure _initialize() never throws
-		await this.initializePromise;
+		this._debug('#__loadSession()', 'begin');
 
-		let currentSession: Session | null = null;
+		if (!this.lockAcquired) {
+			this._debug('#__loadSession()', 'used outside of an acquired lock!', new Error().stack);
+		}
 
-		if (this.persistSession) {
+		try {
+			let currentSession: Session | null = null;
+
 			const maybeSession = await getItemAsync(this.storage, this.storageKey);
+
+			this._debug('#getSession()', 'session from storage', maybeSession);
 
 			if (maybeSession !== null) {
 				if (this._isValidSession(maybeSession)) {
 					currentSession = maybeSession;
 				} else {
+					this._debug('#getSession()', 'session from storage is not valid');
 					await this._removeSession();
 				}
 			}
-		} else {
-			currentSession = this.inMemorySession;
-		}
 
-		if (!currentSession) {
-			return { data: { session: null }, error: null };
-		}
+			if (!currentSession) {
+				return { data: { session: null }, error: null };
+			}
 
-		const hasExpired = currentSession.expires_at ? currentSession.expires_at <= Date.now() / 1000 : false;
-		if (!hasExpired) {
-			return { data: { session: currentSession }, error: null };
-		}
+			const hasExpired = currentSession.expires_at ? currentSession.expires_at <= Date.now() / 1000 : false;
 
-		const { session, error } = await this._callRefreshToken(currentSession.refresh_token);
-		if (error) {
-			return { data: { session: null }, error };
-		}
+			this._debug('#__loadSession()', `session has${hasExpired ? '' : ' not'} expired`, 'expires_at', currentSession.expires_at);
 
-		return { data: { session }, error: null };
+			if (!hasExpired) {
+				return { data: { session: currentSession }, error: null };
+			}
+
+			const { session, error } = await this._callRefreshToken(currentSession.refresh_token);
+
+			if (isAuthRetryableFetchError(error)) {
+				// custom: in case the refresh fails, we still want to keep the user session alive and retry refresh at a later point
+				// this is particularly useful when the device is offline, we don't want to log the user out.
+				return { data: { session: currentSession }, error: null };
+			}
+
+			if (error) {
+				return { data: { session: null }, error };
+			}
+
+			return { data: { session }, error: null };
+		} finally {
+			this._debug('#__loadSession()', 'end');
+		}
 	}
 
 	/**
@@ -620,21 +1011,38 @@ export default class GoTrueClient {
 	 * @param jwt Takes in an optional access token jwt. If no jwt is provided, getUser() will attempt to get the jwt from the current session.
 	 */
 	async getUser(jwt?: string): Promise<UserResponse> {
+		if (jwt) {
+			return await this._getUser(jwt);
+		}
+
+		await this.initializePromise;
+
+		return this._acquireLock(-1, async () => {
+			return await this._getUser();
+		});
+	}
+
+	private async _getUser(jwt?: string): Promise<UserResponse> {
 		try {
-			if (!jwt) {
-				const { data, error } = await this.getSession();
+			if (jwt) {
+				return await _request(this.fetch, 'GET', `${this.url}/user`, {
+					headers: this.headers,
+					jwt: jwt,
+					xform: _userResponse,
+				});
+			}
+
+			return await this._useSession(async (result) => {
+				const { data, error } = result;
 				if (error) {
 					throw error;
 				}
 
-				// Default to Authorization header if there is no existing session
-				jwt = data.session?.access_token ?? undefined;
-			}
-
-			return await _request(this.fetch, 'GET', `${this.url}/user`, {
-				headers: this.headers,
-				jwt: jwt,
-				xform: _userResponse,
+				return await _request(this.fetch, 'GET', `${this.url}/user`, {
+					headers: this.headers,
+					jwt: data.session?.access_token ?? undefined,
+					xform: _userResponse,
+				});
 			});
 		} catch (error) {
 			if (isAuthError(error)) {
@@ -654,28 +1062,55 @@ export default class GoTrueClient {
 			emailRedirectTo?: string | undefined;
 		} = {}
 	): Promise<UserResponse> {
-		try {
-			const { data: sessionData, error: sessionError } = await this.getSession();
-			if (sessionError) {
-				throw sessionError;
-			}
-			if (!sessionData.session) {
-				throw new AuthSessionMissingError();
-			}
-			const session: Session = sessionData.session;
-			const { data, error: userError } = await _request(this.fetch, 'PUT', `${this.url}/user`, {
-				headers: this.headers,
-				redirectTo: options?.emailRedirectTo,
-				body: attributes,
-				jwt: session.access_token,
-				xform: _userResponse,
-			});
-			if (userError) throw userError;
-			session.user = data.user as User;
-			await this._saveSession(session);
-			this._notifyAllSubscribers('USER_UPDATED', session);
+		await this.initializePromise;
 
-			return { data: { user: session.user }, error: null };
+		return await this._acquireLock(-1, async () => {
+			return await this._updateUser(attributes, options);
+		});
+	}
+
+	protected async _updateUser(
+		attributes: UserAttributes,
+		options: {
+			emailRedirectTo?: string | undefined;
+		} = {}
+	): Promise<UserResponse> {
+		try {
+			return await this._useSession(async (result) => {
+				const { data: sessionData, error: sessionError } = result;
+				if (sessionError) {
+					throw sessionError;
+				}
+				if (!sessionData.session) {
+					throw new AuthSessionMissingError();
+				}
+				const session: Session = sessionData.session;
+				let codeChallenge: string | null = null;
+				let codeChallengeMethod: string | null = null;
+				if (this.flowType === 'pkce' && attributes.email != null) {
+					const codeVerifier = generatePKCEVerifier();
+					await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
+					codeChallenge = await generatePKCEChallenge(codeVerifier);
+					codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
+				}
+
+				const { data, error: userError } = await _request(this.fetch, 'PUT', `${this.url}/user`, {
+					headers: this.headers,
+					redirectTo: options?.emailRedirectTo,
+					body: {
+						...attributes,
+						code_challenge: codeChallenge,
+						code_challenge_method: codeChallengeMethod,
+					},
+					jwt: session.access_token,
+					xform: _userResponse,
+				});
+				if (userError) throw userError;
+				session.user = data.user as User;
+				await this._saveSession(session);
+				await this._notifyAllSubscribers('USER_UPDATED', session);
+				return { data: { user: session.user }, error: null };
+			});
 		} catch (error) {
 			if (isAuthError(error)) {
 				return { data: { user: null }, error };
@@ -702,6 +1137,14 @@ export default class GoTrueClient {
 	 * @param currentSession The current session that minimally contains an access token and refresh token.
 	 */
 	async setSession(currentSession: { access_token: string; refresh_token: string }): Promise<AuthResponse> {
+		await this.initializePromise;
+
+		return await this._acquireLock(-1, async () => {
+			return await this._setSession(currentSession);
+		});
+	}
+
+	protected async _setSession(currentSession: { access_token: string; refresh_token: string }): Promise<AuthResponse> {
 		try {
 			if (!currentSession.access_token || !currentSession.refresh_token) {
 				throw new AuthSessionMissingError();
@@ -728,7 +1171,7 @@ export default class GoTrueClient {
 				}
 				session = refreshedSession;
 			} else {
-				const { data, error } = await this.getUser(currentSession.access_token);
+				const { data, error } = await this._getUser(currentSession.access_token);
 				if (error) {
 					throw error;
 				}
@@ -741,7 +1184,7 @@ export default class GoTrueClient {
 					expires_at: expiresAt,
 				};
 				await this._saveSession(session);
-				this._notifyAllSubscribers('SIGNED_IN', session);
+				await this._notifyAllSubscribers('SIGNED_IN', session);
 			}
 
 			return { data: { user: session.user, session }, error: null };
@@ -761,30 +1204,40 @@ export default class GoTrueClient {
 	 * @param currentSession The current session. If passed in, it must contain a refresh token.
 	 */
 	async refreshSession(currentSession?: { refresh_token: string }): Promise<AuthResponse> {
+		await this.initializePromise;
+
+		return await this._acquireLock(-1, async () => {
+			return await this._refreshSession(currentSession);
+		});
+	}
+
+	protected async _refreshSession(currentSession?: { refresh_token: string }): Promise<AuthResponse> {
 		try {
-			if (!currentSession) {
-				const { data, error } = await this.getSession();
-				if (error) {
-					throw error;
+			return await this._useSession(async (result) => {
+				if (!currentSession) {
+					const { data, error } = result;
+					if (error) {
+						throw error;
+					}
+
+					currentSession = data.session ?? undefined;
 				}
 
-				currentSession = data.session ?? undefined;
-			}
+				if (!currentSession?.refresh_token) {
+					throw new AuthSessionMissingError();
+				}
 
-			if (!currentSession?.refresh_token) {
-				throw new AuthSessionMissingError();
-			}
+				const { session, error } = await this._callRefreshToken(currentSession.refresh_token);
+				if (error) {
+					return { data: { user: null, session: null }, error: error };
+				}
 
-			const { session, error } = await this._callRefreshToken(currentSession.refresh_token);
-			if (error) {
-				return { data: { user: null, session: null }, error: error };
-			}
+				if (!session) {
+					return { data: { user: null, session: null }, error: null };
+				}
 
-			if (!session) {
-				return { data: { user: null, session: null }, error: null };
-			}
-
-			return { data: { user: session.user, session }, error: null };
+				return { data: { user: session.user, session }, error: null };
+			});
 		} catch (error) {
 			if (isAuthError(error)) {
 				return { data: { user: null, session: null }, error };
@@ -797,7 +1250,7 @@ export default class GoTrueClient {
 	/**
 	 * Gets the session data from a URL string
 	 */
-	private async _getSessionFromUrl(isPKCEFlow: boolean): Promise<
+	private async _getSessionFromURL(isPKCEFlow: boolean): Promise<
 		| {
 				data: { session: Session; redirectType: string | null };
 				error: null;
@@ -811,55 +1264,74 @@ export default class GoTrueClient {
 			} else if (this.flowType == 'pkce' && !isPKCEFlow) {
 				throw new AuthPKCEGrantCodeExchangeError('Not a valid PKCE flow url.');
 			}
+
+			const params = parseParametersFromURL(window.location.href);
+
 			if (isPKCEFlow) {
-				const authCode = getParameterByName('code');
-				if (!authCode) throw new AuthPKCEGrantCodeExchangeError('No code detected.');
-				const { data, error } = await this.exchangeCodeForSession(authCode);
+				if (!params.code) throw new AuthPKCEGrantCodeExchangeError('No code detected.');
+				const { data, error } = await this._exchangeCodeForSession(params.code);
 				if (error) throw error;
-				if (!data.session) throw new AuthPKCEGrantCodeExchangeError('No session detected.');
+
+				const url = new URL(window.location.href);
+				url.searchParams.delete('code');
+
+				window.history.replaceState(window.history.state, '', url.toString());
+
 				return { data: { session: data.session, redirectType: null }, error: null };
 			}
 
-			const error_description = getParameterByName('error_description');
-			if (error_description) {
-				const error_code = getParameterByName('error_code');
-				if (!error_code) throw new AuthImplicitGrantRedirectError('No error_code detected.');
-				const error = getParameterByName('error');
-				if (!error) throw new AuthImplicitGrantRedirectError('No error detected.');
-
-				throw new AuthImplicitGrantRedirectError(error_description, { error, code: error_code });
+			if (params.error || params.error_description || params.error_code) {
+				throw new AuthImplicitGrantRedirectError(params.error_description || 'Error in URL with unspecified error_description', {
+					error: params.error || 'unspecified_error',
+					code: params.error_code || 'unspecified_code',
+				});
 			}
 
-			const provider_token = getParameterByName('provider_token');
-			const provider_refresh_token = getParameterByName('provider_refresh_token');
-			const access_token = getParameterByName('access_token');
-			if (!access_token) throw new AuthImplicitGrantRedirectError('No access_token detected.');
-			const expires_in = getParameterByName('expires_in');
-			if (!expires_in) throw new AuthImplicitGrantRedirectError('No expires_in detected.');
-			const refresh_token = getParameterByName('refresh_token');
-			if (!refresh_token) throw new AuthImplicitGrantRedirectError('No refresh_token detected.');
-			const token_type = getParameterByName('token_type');
-			if (!token_type) throw new AuthImplicitGrantRedirectError('No token_type detected.');
+			const { provider_token, provider_refresh_token, access_token, refresh_token, expires_in, expires_at, token_type } = params;
+
+			if (!access_token || !expires_in || !refresh_token || !token_type) {
+				throw new AuthImplicitGrantRedirectError('No session defined in URL');
+			}
 
 			const timeNow = Math.round(Date.now() / 1000);
-			const expires_at = timeNow + parseInt(expires_in);
+			const expiresIn = parseInt(expires_in);
+			let expiresAt = timeNow + expiresIn;
 
-			const { data, error } = await this.getUser(access_token);
+			if (expires_at) {
+				expiresAt = parseInt(expires_at);
+			}
+
+			const actuallyExpiresIn = expiresAt - timeNow;
+			if (actuallyExpiresIn * 1000 <= AUTO_REFRESH_TICK_DURATION) {
+				console.warn(`@supabase/gotrue-js: Session as retrieved from URL expires in ${actuallyExpiresIn}s, should have been closer to ${expiresIn}s`);
+			}
+
+			const issuedAt = expiresAt - expiresIn;
+			if (timeNow - issuedAt >= 120) {
+				console.warn('@supabase/gotrue-js: Session as retrieved from URL was issued over 120s ago, URL could be stale', issuedAt, expiresAt, timeNow);
+			} else if (timeNow - issuedAt < 0) {
+				console.warn('@supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clok for skew', issuedAt, expiresAt, timeNow);
+			}
+
+			const { data, error } = await this._getUser(access_token);
 			if (error) throw error;
-			const user: User = data.user;
+
 			const session: Session = {
 				provider_token,
 				provider_refresh_token,
 				access_token,
-				expires_in: parseInt(expires_in),
-				expires_at,
+				expires_in: expiresIn,
+				expires_at: expiresAt,
 				refresh_token,
 				token_type,
-				user,
+				user: data.user,
 			};
-			const redirectType = getParameterByName('type');
 
-			return { data: { session, redirectType }, error: null };
+			// Remove tokens from URL
+			window.location.hash = '';
+			this._debug('#_getSessionFromURL()', 'clearing window.location.hash');
+
+			return { data: { session, redirectType: params.type }, error: null };
 		} catch (error) {
 			if (isAuthError(error)) {
 				return { data: { session: null, redirectType: null }, error };
@@ -873,49 +1345,69 @@ export default class GoTrueClient {
 	 * Checks if the current URL contains parameters given by an implicit oauth grant flow (https://www.rfc-editor.org/rfc/rfc6749.html#section-4.2)
 	 */
 	private _isImplicitGrantFlow(): boolean {
-		return isBrowser() && (Boolean(getParameterByName('access_token')) || Boolean(getParameterByName('error_description')));
+		const params = parseParametersFromURL(window.location.href);
+
+		return !!(isBrowser() && (params.access_token || params.error_description));
 	}
+
 	/**
 	 * Checks if the current URL and backing storage contain parameters given by a PKCE flow
 	 */
 	private async _isPKCEFlow(): Promise<boolean> {
+		const params = parseParametersFromURL(window.location.href);
+
 		const currentStorageContent = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`);
-		return isBrowser() && Boolean(getParameterByName('code')) && Boolean(currentStorageContent);
+
+		return !!(params.code && currentStorageContent);
 	}
 
 	/**
-	 * Inside a browser context, `signOut()` will remove the logged in user from the browser session
-	 * and log them out - removing all items from localstorage and then trigger a `"SIGNED_OUT"` event.
+	 * Inside a browser context, `signOut()` will remove the logged in user from the browser session and log them out - removing all items from localstorage and then trigger a `"SIGNED_OUT"` event.
 	 *
 	 * For server-side management, you can revoke all refresh tokens for a user by passing a user's JWT through to `auth.api.signOut(JWT: string)`.
 	 * There is no way to revoke a user's access token jwt until it expires. It is recommended to set a shorter expiry on the jwt for this reason.
+	 *
+	 * If using `others` scope, no `SIGNED_OUT` event is fired!
 	 */
-	async signOut(): Promise<{ error: AuthError | null }> {
-		const { data, error: sessionError } = await this.getSession();
-		if (sessionError) {
-			return { error: sessionError };
-		}
-		const accessToken = data.session?.access_token;
-		if (accessToken) {
-			const { error } = await this.admin.signOut(accessToken);
-			if (error) {
-				// ignore 404s since user might not exist anymore
-				// ignore 401s since an invalid or expired JWT should sign out the current session
-				if (!(isAuthApiError(error) && (error.status === 404 || error.status === 401))) {
-					return { error };
+	async signOut(options: SignOut = { scope: 'global' }): Promise<{ error: AuthError | null }> {
+		await this.initializePromise;
+
+		return await this._acquireLock(-1, async () => {
+			return await this._signOut(options);
+		});
+	}
+
+	protected async _signOut({ scope }: SignOut = { scope: 'global' }): Promise<{ error: AuthError | null }> {
+		return await this._useSession(async (result) => {
+			const { data, error: sessionError } = result;
+			if (sessionError) {
+				return { error: sessionError };
+			}
+			const accessToken = data.session?.access_token;
+			if (accessToken) {
+				const { error } = await this.admin.signOut(accessToken, scope);
+				if (error) {
+					// ignore 404s since user might not exist anymore
+					// ignore 401s since an invalid or expired JWT should sign out the current session
+					if (!(isAuthApiError(error) && (error.status === 404 || error.status === 401))) {
+						return { error };
+					}
 				}
 			}
-		}
-		await this._removeSession();
-		this._notifyAllSubscribers('SIGNED_OUT', null);
-		return { error: null };
+			if (scope !== 'others') {
+				await this._removeSession();
+				await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`);
+				await this._notifyAllSubscribers('SIGNED_OUT', null);
+			}
+			return { error: null };
+		});
 	}
 
 	/**
 	 * Receive a notification every time an auth event happens.
 	 * @param callback A callback function to be invoked when an auth event happens.
 	 */
-	onAuthStateChange(callback: (event: AuthChangeEvent, session: Session | null) => void): {
+	onAuthStateChange(callback: (event: AuthChangeEvent, session: Session | null) => void | Promise<void>): {
 		data: { subscription: Subscription };
 	} {
 		const id: string = uuid();
@@ -923,34 +1415,48 @@ export default class GoTrueClient {
 			id,
 			callback,
 			unsubscribe: () => {
+				this._debug('#unsubscribe()', 'state change callback with id removed', id);
+
 				this.stateChangeEmitters.delete(id);
 			},
 		};
 
-		this.stateChangeEmitters.set(id, subscription);
+		this._debug('#onAuthStateChange()', 'registered callback with id', id);
 
-		this.emitInitialSession(id);
+		this.stateChangeEmitters.set(id, subscription);
+		(async () => {
+			await this.initializePromise;
+
+			await this._acquireLock(-1, async () => {
+				this._emitInitialSession(id);
+			});
+		})();
 
 		return { data: { subscription } };
 	}
 
-	private async emitInitialSession(id: string): Promise<void> {
-		try {
-			const {
-				data: { session },
-				error,
-			} = await this.getSession();
-			if (error) throw error;
+	private async _emitInitialSession(id: string): Promise<void> {
+		return await this._useSession(async (result) => {
+			try {
+				const {
+					data: { session },
+					error,
+				} = result;
+				if (error) throw error;
 
-			this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', session);
-		} catch (err) {
-			this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null);
-			console.error(err);
-		}
+				await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', session);
+				this._debug('INITIAL_SESSION', 'callback id', id, 'session', session);
+			} catch (err) {
+				await this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null);
+				this._debug('INITIAL_SESSION', 'callback id', id, 'error', err);
+				console.error(err);
+			}
+		});
 	}
 
 	/**
-	 * Sends a password reset request to an email address.
+	 * Sends a password reset request to an email address. This method supports the PKCE flow.
+	 *
 	 * @param email The email address of the user.
 	 * @param options.redirectTo The URL to send the user to after they click the password reset link.
 	 * @param options.captchaToken Verification token received when the user completes the captcha on the site.
@@ -963,24 +1469,25 @@ export default class GoTrueClient {
 		} = {}
 	): Promise<
 		| {
-				// eslint-disable-next-line @typescript-eslint/ban-types
 				data: {};
 				error: null;
 		  }
 		| { data: null; error: AuthError }
 	> {
-		let codeChallenge = null;
+		let codeChallenge: string | null = null;
+		let codeChallengeMethod: string | null = null;
 		if (this.flowType === 'pkce') {
 			const codeVerifier = generatePKCEVerifier();
-			await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
+			await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, `${codeVerifier}/PASSWORD_RECOVERY`);
 			codeChallenge = await generatePKCEChallenge(codeVerifier);
+			codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
 		}
 		try {
 			return await _request(this.fetch, 'POST', `${this.url}/recover`, {
 				body: {
 					email,
 					code_challenge: codeChallenge,
-					code_challenge_method: codeChallenge ? 's256' : null,
+					code_challenge_method: codeChallengeMethod,
 					gotrue_meta_security: { captcha_token: options.captchaToken },
 				},
 				headers: this.headers,
@@ -996,10 +1503,98 @@ export default class GoTrueClient {
 	}
 
 	/**
+	 * Gets all the identities linked to a user.
+	 */
+	async getUserIdentities(): Promise<
+		| {
+				data: {
+					identities: UserIdentity[];
+				};
+				error: null;
+		  }
+		| { data: null; error: AuthError }
+	> {
+		try {
+			const { data, error } = await this.getUser();
+			if (error) throw error;
+			return { data: { identities: data.user.identities ?? [] }, error: null };
+		} catch (error) {
+			if (isAuthError(error)) {
+				return { data: null, error };
+			}
+			throw error;
+		}
+	}
+	/**
+	 * Links an oauth identity to an existing user.
+	 * This method supports the PKCE flow.
+	 */
+	async linkIdentity(credentials: SignInWithOAuthCredentials): Promise<OAuthResponse> {
+		try {
+			const { data, error } = await this._useSession(async (result) => {
+				const { data, error } = result;
+				if (error) throw error;
+				const url: string = await this._getUrlForProvider(`${this.url}/user/identities/authorize`, credentials.provider, {
+					redirectTo: credentials.options?.redirectTo,
+					scopes: credentials.options?.scopes,
+					queryParams: credentials.options?.queryParams,
+					skipBrowserRedirect: true,
+				});
+				return await _request(this.fetch, 'GET', url, {
+					headers: this.headers,
+					jwt: data.session?.access_token ?? undefined,
+				});
+			});
+			if (error) throw error;
+			if (isBrowser() && !credentials.options?.skipBrowserRedirect) {
+				window.location.assign(data?.url);
+			}
+			return { data: { provider: credentials.provider, url: data?.url }, error: null };
+		} catch (error) {
+			if (isAuthError(error)) {
+				return { data: { provider: credentials.provider, url: null }, error };
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Unlinks an identity from a user by deleting it. The user will no longer be able to sign in with that identity once it's unlinked.
+	 */
+	async unlinkIdentity(identity: UserIdentity): Promise<
+		| {
+				data: {};
+				error: null;
+		  }
+		| { data: null; error: AuthError }
+	> {
+		try {
+			return await this._useSession(async (result) => {
+				const { data, error } = result;
+				if (error) {
+					throw error;
+				}
+				return await _request(this.fetch, 'DELETE', `${this.url}/user/identities/${identity.identity_id}`, {
+					headers: this.headers,
+					jwt: data.session?.access_token ?? undefined,
+				});
+			});
+		} catch (error) {
+			if (isAuthError(error)) {
+				return { data: null, error };
+			}
+			throw error;
+		}
+	}
+
+	/**
 	 * Generates a new JWT.
 	 * @param refreshToken A valid refresh token that was returned on login.
 	 */
 	private async _refreshAccessToken(refreshToken: string): Promise<AuthResponse> {
+		const debugName = `#_refreshAccessToken(${refreshToken.substring(0, 5)}...)`;
+		this._debug(debugName, 'begin');
+
 		try {
 			const startedAt = Date.now();
 
@@ -1007,6 +1602,8 @@ export default class GoTrueClient {
 			return await retryable(
 				async (attempt) => {
 					await sleep(attempt * 200); // 0, 200, 400, 800, ...
+
+					this._debug(debugName, 'refreshing attempt', attempt);
 
 					return await _request(this.fetch, 'POST', `${this.url}/token?grant_type=refresh_token`, {
 						body: { refresh_token: refreshToken },
@@ -1017,15 +1614,19 @@ export default class GoTrueClient {
 				(attempt, _, result) =>
 					result &&
 					result.error &&
-					result.error instanceof AuthRetryableFetchError &&
+					isAuthRetryableFetchError(result.error) &&
 					// retryable only if the request can be sent before the backoff overflows the tick duration
 					Date.now() + (attempt + 1) * 200 - startedAt < AUTO_REFRESH_TICK_DURATION
 			);
 		} catch (error) {
+			this._debug(debugName, 'error', error);
+
 			if (isAuthError(error)) {
 				return { data: { session: null, user: null }, error };
 			}
 			throw error;
+		} finally {
+			this._debug(debugName, 'end');
 		}
 	}
 
@@ -1044,15 +1645,18 @@ export default class GoTrueClient {
 			skipBrowserRedirect?: boolean;
 		}
 	) {
-		const url: string = await this._getUrlForProvider(provider, {
+		const url: string = await this._getUrlForProvider(`${this.url}/authorize`, provider, {
 			redirectTo: options.redirectTo,
 			scopes: options.scopes,
 			queryParams: options.queryParams,
 		});
+
+		this._debug('#_handleProviderSignIn()', 'provider', provider, 'options', options, 'url', url);
+
 		// try to open on the browser
-		// if (isBrowser() && !options.skipBrowserRedirect) {
-		//   window.location.assign(url)
-		// }
+		if (isBrowser() && !options.skipBrowserRedirect) {
+			window.location.assign(url);
+		}
 
 		return { data: { provider, url }, error: null };
 	}
@@ -1062,9 +1666,15 @@ export default class GoTrueClient {
 	 * Note: this method is async to accommodate for AsyncStorage e.g. in React native.
 	 */
 	private async _recoverAndRefresh() {
+		const debugName = '#_recoverAndRefresh()';
+		this._debug(debugName, 'begin');
+
 		try {
 			const currentSession = await getItemAsync(this.storage, this.storageKey);
+			this._debug(debugName, 'session from storage', currentSession);
+
 			if (!this._isValidSession(currentSession)) {
+				this._debug(debugName, 'session is not valid');
 				if (currentSession !== null) {
 					await this._removeSession();
 				}
@@ -1073,48 +1683,62 @@ export default class GoTrueClient {
 			}
 
 			const timeNow = Math.round(Date.now() / 1000);
+			const expiresWithMargin = (currentSession.expires_at ?? Infinity) < timeNow + EXPIRY_MARGIN;
 
-			if ((currentSession.expires_at ?? Infinity) < timeNow + EXPIRY_MARGIN) {
+			this._debug(debugName, `session has${expiresWithMargin ? '' : ' not'} expired with margin of ${EXPIRY_MARGIN}s`);
+
+			if (expiresWithMargin) {
 				if (this.autoRefreshToken && currentSession.refresh_token) {
 					const { error } = await this._callRefreshToken(currentSession.refresh_token);
 
 					if (error) {
-						console.log(error.message);
-						await this._removeSession();
+						console.error(error);
+
+						if (!isAuthRetryableFetchError(error)) {
+							this._debug(debugName, 'refresh failed with a non-retryable error, removing the session', error);
+							await this._removeSession();
+						}
 					}
-				} else {
-					await this._removeSession();
 				}
 			} else {
-				if (this.persistSession) {
-					await this._saveSession(currentSession);
-				}
-				this._notifyAllSubscribers('SIGNED_IN', currentSession);
+				// no need to persist currentSession again, as we just loaded it from
+				// local storage; persisting it again may overwrite a value saved by
+				// another client with access to the same local storage
+				await this._notifyAllSubscribers('SIGNED_IN', currentSession);
 			}
 		} catch (err) {
+			this._debug(debugName, 'error', err);
+
 			console.error(err);
 			return;
+		} finally {
+			this._debug(debugName, 'end');
 		}
 	}
 
 	private async _callRefreshToken(refreshToken: string): Promise<CallRefreshTokenResult> {
+		if (!refreshToken) {
+			throw new AuthSessionMissingError();
+		}
+
 		// refreshing is already in progress
 		if (this.refreshingDeferred) {
 			return this.refreshingDeferred.promise;
 		}
 
+		const debugName = `#_callRefreshToken(${refreshToken.substring(0, 5)}...)`;
+
+		this._debug(debugName, 'begin');
+
 		try {
 			this.refreshingDeferred = new Deferred<CallRefreshTokenResult>();
 
-			if (!refreshToken) {
-				throw new AuthSessionMissingError();
-			}
 			const { data, error } = await this._refreshAccessToken(refreshToken);
 			if (error) throw error;
 			if (!data.session) throw new AuthSessionMissingError();
 
 			await this._saveSession(data.session);
-			this._notifyAllSubscribers('TOKEN_REFRESHED', data.session);
+			await this._notifyAllSubscribers('TOKEN_REFRESHED', data.session);
 
 			const result = { session: data.session, error: null };
 
@@ -1122,8 +1746,15 @@ export default class GoTrueClient {
 
 			return result;
 		} catch (error) {
+			this._debug(debugName, 'error', error);
+
 			if (isAuthError(error)) {
 				const result = { session: null, error };
+
+				if (!isAuthRetryableFetchError(error)) {
+					await this._removeSession();
+					await this._notifyAllSubscribers('SIGNED_OUT', null);
+				}
 
 				this.refreshingDeferred?.resolve(result);
 
@@ -1134,11 +1765,40 @@ export default class GoTrueClient {
 			throw error;
 		} finally {
 			this.refreshingDeferred = null;
+			this._debug(debugName, 'end');
 		}
 	}
 
-	private _notifyAllSubscribers(event: AuthChangeEvent, session: Session | null, _broadcast = true) {
-		this.stateChangeEmitters.forEach((x) => x.callback(event, session));
+	private async _notifyAllSubscribers(event: AuthChangeEvent, session: Session | null, broadcast = true) {
+		const debugName = `#_notifyAllSubscribers(${event})`;
+		this._debug(debugName, 'begin', session, `broadcast = ${broadcast}`);
+
+		try {
+			if (this.broadcastChannel && broadcast) {
+				this.broadcastChannel.postMessage({ event, session });
+			}
+
+			const errors: any[] = [];
+			const promises = Array.from(this.stateChangeEmitters.values()).map(async (x) => {
+				try {
+					await x.callback(event, session);
+				} catch (e: any) {
+					errors.push(e);
+				}
+			});
+
+			await Promise.all(promises);
+
+			if (errors.length > 0) {
+				for (let i = 0; i < errors.length; i += 1) {
+					console.error(errors[i]);
+				}
+
+				throw errors[0];
+			}
+		} finally {
+			this._debug(debugName, 'end');
+		}
 	}
 
 	/**
@@ -1146,25 +1806,15 @@ export default class GoTrueClient {
 	 * process to _startAutoRefreshToken if possible
 	 */
 	private async _saveSession(session: Session) {
-		if (!this.persistSession) {
-			this.inMemorySession = session;
-		}
+		this._debug('#_saveSession()', session);
 
-		if (this.persistSession && session.expires_at) {
-			await this._persistSession(session);
-		}
-	}
-
-	private _persistSession(currentSession: Session) {
-		return setItemAsync(this.storage, this.storageKey, currentSession);
+		await setItemAsync(this.storage, this.storageKey, session);
 	}
 
 	private async _removeSession() {
-		if (this.persistSession) {
-			await removeItemAsync(this.storage, this.storageKey);
-		} else {
-			this.inMemorySession = null;
-		}
+		this._debug('#_removeSession()');
+
+		await removeItemAsync(this.storage, this.storageKey);
 	}
 
 	/**
@@ -1173,20 +1823,20 @@ export default class GoTrueClient {
 	 * {@see #startAutoRefresh}
 	 * {@see #stopAutoRefresh}
 	 */
-	// private _removeVisibilityChangedCallback() {
-	// 	return;
+	private _removeVisibilityChangedCallback() {
+		this._debug('#_removeVisibilityChangedCallback()');
 
-	// 	const callback = this.visibilityChangedCallback;
-	// 	this.visibilityChangedCallback = null;
+		const callback = this.visibilityChangedCallback;
+		this.visibilityChangedCallback = null;
 
-	// 	try {
-	// 		if (callback && isBrowser() && window?.removeEventListener) {
-	// 			window.removeEventListener('visibilitychange', callback);
-	// 		}
-	// 	} catch (e) {
-	// 		console.error('removing visibilitychange callback failed', e);
-	// 	}
-	// }
+		try {
+			if (callback && isBrowser() && window?.removeEventListener) {
+				window.removeEventListener('visibilitychange', callback);
+			}
+		} catch (e) {
+			console.error('removing visibilitychange callback failed', e);
+		}
+	}
 
 	/**
 	 * This is the private implementation of {@link #startAutoRefresh}. Use this
@@ -1194,6 +1844,8 @@ export default class GoTrueClient {
 	 */
 	private async _startAutoRefresh() {
 		await this._stopAutoRefresh();
+
+		this._debug('#_startAutoRefresh()');
 
 		const ticker = setInterval(() => this._autoRefreshTokenTick(), AUTO_REFRESH_TICK_DURATION);
 		this.autoRefreshTicker = ticker;
@@ -1206,10 +1858,21 @@ export default class GoTrueClient {
 			// finished and tests run endlessly. This can be prevented by calling
 			// `unref()` on the returned object.
 			ticker.unref();
+			// @ts-ignore
+		} else if (typeof Deno !== 'undefined' && typeof Deno.unrefTimer === 'function') {
+			// similar like for NodeJS, but with the Deno API
+			// https://deno.land/api@latest?unstable&s=Deno.unrefTimer
+			// @ts-ignore
+			Deno.unrefTimer(ticker);
 		}
 
-		// run the tick immediately
-		await this._autoRefreshTokenTick();
+		// run the tick immediately, but in the next pass of the event loop so that
+		// #_initialize can be allowed to complete without recursively waiting on
+		// itself
+		setTimeout(async () => {
+			await this.initializePromise;
+			await this._autoRefreshTokenTick();
+		}, 0);
 	}
 
 	/**
@@ -1217,6 +1880,8 @@ export default class GoTrueClient {
 	 * within the library.
 	 */
 	private async _stopAutoRefresh() {
+		this._debug('#_stopAutoRefresh()');
+
 		const ticker = this.autoRefreshTicker;
 		this.autoRefreshTicker = null;
 
@@ -1241,14 +1906,14 @@ export default class GoTrueClient {
 	 * changes on your own.
 	 *
 	 * On non-browser platforms the refresh process works *continuously* in the
-	 * background, which may not be desireable. You should hook into your
+	 * background, which may not be desirable. You should hook into your
 	 * platform's foreground indication mechanism and call these methods
 	 * appropriately to conserve resources.
 	 *
 	 * {@see #stopAutoRefresh}
 	 */
 	async startAutoRefresh() {
-		// this._removeVisibilityChangedCallback();
+		this._removeVisibilityChangedCallback();
 		await this._startAutoRefresh();
 	}
 
@@ -1261,7 +1926,7 @@ export default class GoTrueClient {
 	 * See {@link #startAutoRefresh} for more details.
 	 */
 	async stopAutoRefresh() {
-		// this._removeVisibilityChangedCallback();
+		this._removeVisibilityChangedCallback();
 		await this._stopAutoRefresh();
 	}
 
@@ -1269,25 +1934,46 @@ export default class GoTrueClient {
 	 * Runs the auto refresh token tick.
 	 */
 	private async _autoRefreshTokenTick() {
-		const now = Date.now();
+		this._debug('#_autoRefreshTokenTick()', 'begin');
 
 		try {
-			const {
-				data: { session },
-			} = await this.getSession();
+			await this._acquireLock(0, async () => {
+				try {
+					const now = Date.now();
 
-			if (!session || !session.refresh_token || !session.expires_at) {
-				return;
-			}
+					try {
+						return await this._useSession(async (result) => {
+							const {
+								data: { session },
+							} = result;
 
-			// session will expire in this many ticks (or has already expired if <= 0)
-			const expiresInTicks = Math.floor((session.expires_at * 1000 - now) / AUTO_REFRESH_TICK_DURATION);
+							if (!session || !session.refresh_token || !session.expires_at) {
+								this._debug('#_autoRefreshTokenTick()', 'no session');
+								return;
+							}
 
-			if (expiresInTicks < AUTO_REFRESH_TICK_THRESHOLD) {
-				await this._callRefreshToken(session.refresh_token);
-			}
+							// session will expire in this many ticks (or has already expired if <= 0)
+							const expiresInTicks = Math.floor((session.expires_at * 1000 - now) / AUTO_REFRESH_TICK_DURATION);
+
+							this._debug('#_autoRefreshTokenTick()', `access token expires in ${expiresInTicks} ticks, a tick lasts ${AUTO_REFRESH_TICK_DURATION}ms, refresh threshold is ${AUTO_REFRESH_TICK_THRESHOLD} ticks`);
+
+							if (expiresInTicks <= AUTO_REFRESH_TICK_THRESHOLD) {
+								await this._callRefreshToken(session.refresh_token);
+							}
+						});
+					} catch (e: any) {
+						console.error('Auto refresh tick failed with error. This is likely a transient error.', e);
+					}
+				} finally {
+					this._debug('#_autoRefreshTokenTick()', 'end');
+				}
+			});
 		} catch (e: any) {
-			console.error('Auto refresh tick failed with error. This is likely a transient error.', e);
+			// if (e.isAcquireTimeout || e instanceof LockAcquireTimeoutError) {
+			// 	this._debug('auto refresh token tick lock not available');
+			// } else {
+			throw e;
+			// }
 		}
 	}
 
@@ -1308,24 +1994,36 @@ export default class GoTrueClient {
 	/**
 	 * Callback registered with `window.addEventListener('visibilitychange')`.
 	 */
-	private async _onVisibilityChanged(isInitial: boolean) {
-		if (document.visibilityState === 'visible') {
-			if (!isInitial) {
-				// initial visibility change setup is handled in another flow under #initialize()
-				await this.initializePromise;
-				await this._recoverAndRefresh();
-			}
-
-			if (this.autoRefreshToken) {
-				// in browser environments the refresh token ticker runs only on focused tabs
-				// which prevents race conditions
-				this._startAutoRefresh();
-			}
-		} else if (document.visibilityState === 'hidden') {
-			if (this.autoRefreshToken) {
-				this._stopAutoRefresh();
-			}
-		}
+	private async _onVisibilityChanged(calledFromInitialize: boolean) {
+		// const methodName = `#_onVisibilityChanged(${calledFromInitialize})`;
+		// this._debug(methodName, 'visibilityState', document.visibilityState);
+		// if (document.visibilityState === 'visible') {
+		// 	if (this.autoRefreshToken) {
+		// 		// in browser environments the refresh token ticker runs only on focused tabs
+		// 		// which prevents race conditions
+		// 		this._startAutoRefresh();
+		// 	}
+		// 	if (!calledFromInitialize) {
+		// 		// called when the visibility has changed, i.e. the browser
+		// 		// transitioned from hidden -> visible so we need to see if the session
+		// 		// should be recovered immediately... but to do that we need to acquire
+		// 		// the lock first asynchronously
+		// 		await this.initializePromise;
+		// 		await this._acquireLock(-1, async () => {
+		// 			if (document.visibilityState !== 'visible') {
+		// 				this._debug(methodName, 'acquired the lock to recover the session, but the browser visibilityState is no longer visible, aborting');
+		// 				// visibility has changed while waiting for the lock, abort
+		// 				return;
+		// 			}
+		// 			// recover the session
+		// 			await this._recoverAndRefresh();
+		// 		});
+		// 	}
+		// } else if (document.visibilityState === 'hidden') {
+		// 	if (this.autoRefreshToken) {
+		// 		this._stopAutoRefresh();
+		// 	}
+		// }
 	}
 
 	/**
@@ -1335,11 +2033,13 @@ export default class GoTrueClient {
 	 * @param options.queryParams An object of key-value pairs containing query parameters granted to the OAuth application.
 	 */
 	private async _getUrlForProvider(
+		url: string,
 		provider: Provider,
 		options: {
 			redirectTo?: string;
 			scopes?: string;
 			queryParams?: { [key: string]: string };
+			skipBrowserRedirect?: boolean;
 		}
 	) {
 		const urlParams: string[] = [`provider=${encodeURIComponent(provider)}`];
@@ -1353,9 +2053,13 @@ export default class GoTrueClient {
 			const codeVerifier = generatePKCEVerifier();
 			await setItemAsync(this.storage, `${this.storageKey}-code-verifier`, codeVerifier);
 			const codeChallenge = await generatePKCEChallenge(codeVerifier);
+			const codeChallengeMethod = codeVerifier === codeChallenge ? 'plain' : 's256';
+
+			this._debug('PKCE', 'code verifier', `${codeVerifier.substring(0, 5)}...`, 'code challenge', codeChallenge, 'method', codeChallengeMethod);
+
 			const flowParams = new URLSearchParams({
 				code_challenge: `${encodeURIComponent(codeChallenge)}`,
-				code_challenge_method: `${encodeURIComponent('s256')}`,
+				code_challenge_method: `${encodeURIComponent(codeChallengeMethod)}`,
 			});
 			urlParams.push(flowParams.toString());
 		}
@@ -1363,20 +2067,25 @@ export default class GoTrueClient {
 			const query = new URLSearchParams(options.queryParams);
 			urlParams.push(query.toString());
 		}
+		if (options?.skipBrowserRedirect) {
+			urlParams.push(`skip_http_redirect=${options.skipBrowserRedirect}`);
+		}
 
-		return `${this.url}/authorize?${urlParams.join('&')}`;
+		return `${url}?${urlParams.join('&')}`;
 	}
 
 	private async _unenroll(params: MFAUnenrollParams): Promise<AuthMFAUnenrollResponse> {
 		try {
-			const { data: sessionData, error: sessionError } = await this.getSession();
-			if (sessionError) {
-				return { data: null, error: sessionError };
-			}
+			return await this._useSession(async (result) => {
+				const { data: sessionData, error: sessionError } = result;
+				if (sessionError) {
+					return { data: null, error: sessionError };
+				}
 
-			return await _request(this.fetch, 'DELETE', `${this.url}/factors/${params.factorId}`, {
-				headers: this.headers,
-				jwt: sessionData?.session?.access_token,
+				return await _request(this.fetch, 'DELETE', `${this.url}/factors/${params.factorId}`, {
+					headers: this.headers,
+					jwt: sessionData?.session?.access_token,
+				});
 			});
 		} catch (error) {
 			if (isAuthError(error)) {
@@ -1391,30 +2100,32 @@ export default class GoTrueClient {
 	 */
 	private async _enroll(params: MFAEnrollParams): Promise<AuthMFAEnrollResponse> {
 		try {
-			const { data: sessionData, error: sessionError } = await this.getSession();
-			if (sessionError) {
-				return { data: null, error: sessionError };
-			}
+			return await this._useSession(async (result) => {
+				const { data: sessionData, error: sessionError } = result;
+				if (sessionError) {
+					return { data: null, error: sessionError };
+				}
 
-			const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
-				body: {
-					friendly_name: params.friendlyName,
-					factor_type: params.factorType,
-					issuer: params.issuer,
-				},
-				headers: this.headers,
-				jwt: sessionData?.session?.access_token,
+				const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors`, {
+					body: {
+						friendly_name: params.friendlyName,
+						factor_type: params.factorType,
+						issuer: params.issuer,
+					},
+					headers: this.headers,
+					jwt: sessionData?.session?.access_token,
+				});
+
+				if (error) {
+					return { data: null, error };
+				}
+
+				if (data?.totp?.qr_code) {
+					data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`;
+				}
+
+				return { data, error: null };
 			});
-
-			if (error) {
-				return { data: null, error };
-			}
-
-			if (data?.totp?.qr_code) {
-				data.totp.qr_code = `data:image/svg+xml;utf-8,${data.totp.qr_code}`;
-			}
-
-			return { data, error: null };
 		} catch (error) {
 			if (isAuthError(error)) {
 				return { data: null, error };
@@ -1427,68 +2138,80 @@ export default class GoTrueClient {
 	 * {@see GoTrueMFAApi#verify}
 	 */
 	private async _verify(params: MFAVerifyParams): Promise<AuthMFAVerifyResponse> {
-		try {
-			const { data: sessionData, error: sessionError } = await this.getSession();
-			if (sessionError) {
-				return { data: null, error: sessionError };
-			}
+		return this._acquireLock(-1, async () => {
+			try {
+				return await this._useSession(async (result) => {
+					const { data: sessionData, error: sessionError } = result;
+					if (sessionError) {
+						return { data: null, error: sessionError };
+					}
 
-			const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors/${params.factorId}/verify`, {
-				body: { code: params.code, challenge_id: params.challengeId },
-				headers: this.headers,
-				jwt: sessionData?.session?.access_token,
-			});
-			if (error) {
-				return { data: null, error };
-			}
+					const { data, error } = await _request(this.fetch, 'POST', `${this.url}/factors/${params.factorId}/verify`, {
+						body: { code: params.code, challenge_id: params.challengeId },
+						headers: this.headers,
+						jwt: sessionData?.session?.access_token,
+					});
+					if (error) {
+						return { data: null, error };
+					}
 
-			await this._saveSession({
-				expires_at: Math.round(Date.now() / 1000) + data.expires_in,
-				...data,
-			});
-			this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data);
+					await this._saveSession({
+						expires_at: Math.round(Date.now() / 1000) + data.expires_in,
+						...data,
+					});
+					await this._notifyAllSubscribers('MFA_CHALLENGE_VERIFIED', data);
 
-			return { data, error };
-		} catch (error) {
-			if (isAuthError(error)) {
-				return { data: null, error };
+					return { data, error };
+				});
+			} catch (error) {
+				if (isAuthError(error)) {
+					return { data: null, error };
+				}
+				throw error;
 			}
-			throw error;
-		}
+		});
 	}
 
 	/**
 	 * {@see GoTrueMFAApi#challenge}
 	 */
 	private async _challenge(params: MFAChallengeParams): Promise<AuthMFAChallengeResponse> {
-		try {
-			const { data: sessionData, error: sessionError } = await this.getSession();
-			if (sessionError) {
-				return { data: null, error: sessionError };
-			}
+		return this._acquireLock(-1, async () => {
+			try {
+				return await this._useSession(async (result) => {
+					const { data: sessionData, error: sessionError } = result;
+					if (sessionError) {
+						return { data: null, error: sessionError };
+					}
 
-			return await _request(this.fetch, 'POST', `${this.url}/factors/${params.factorId}/challenge`, {
-				headers: this.headers,
-				jwt: sessionData?.session?.access_token,
-			});
-		} catch (error) {
-			if (isAuthError(error)) {
-				return { data: null, error };
+					return await _request(this.fetch, 'POST', `${this.url}/factors/${params.factorId}/challenge`, {
+						headers: this.headers,
+						jwt: sessionData?.session?.access_token,
+					});
+				});
+			} catch (error) {
+				if (isAuthError(error)) {
+					return { data: null, error };
+				}
+				throw error;
 			}
-			throw error;
-		}
+		});
 	}
 
 	/**
 	 * {@see GoTrueMFAApi#challengeAndVerify}
 	 */
 	private async _challengeAndVerify(params: MFAChallengeAndVerifyParams): Promise<AuthMFAVerifyResponse> {
+		// both _challenge and _verify independently acquire the lock, so no need
+		// to acquire it here
+
 		const { data: challengeData, error: challengeError } = await this._challenge({
 			factorId: params.factorId,
 		});
 		if (challengeError) {
 			return { data: null, error: challengeError };
 		}
+
 		return await this._verify({
 			factorId: params.factorId,
 			challengeId: challengeData.id,
@@ -1500,6 +2223,7 @@ export default class GoTrueClient {
 	 * {@see GoTrueMFAApi#listFactors}
 	 */
 	private async _listFactors(): Promise<AuthMFAListFactorsResponse> {
+		// use #getUser instead of #_getUser as the former acquires a lock
 		const {
 			data: { user },
 			error: userError,
@@ -1524,38 +2248,42 @@ export default class GoTrueClient {
 	 * {@see GoTrueMFAApi#getAuthenticatorAssuranceLevel}
 	 */
 	private async _getAuthenticatorAssuranceLevel(): Promise<AuthMFAGetAuthenticatorAssuranceLevelResponse> {
-		const {
-			data: { session },
-			error: sessionError,
-		} = await this.getSession();
-		if (sessionError) {
-			return { data: null, error: sessionError };
-		}
-		if (!session) {
-			return {
-				data: { currentLevel: null, nextLevel: null, currentAuthenticationMethods: [] },
-				error: null,
-			};
-		}
+		return this._acquireLock(-1, async () => {
+			return await this._useSession(async (result) => {
+				const {
+					data: { session },
+					error: sessionError,
+				} = result;
+				if (sessionError) {
+					return { data: null, error: sessionError };
+				}
+				if (!session) {
+					return {
+						data: { currentLevel: null, nextLevel: null, currentAuthenticationMethods: [] },
+						error: null,
+					};
+				}
 
-		const payload = this._decodeJWT(session.access_token);
+				const payload = this._decodeJWT(session.access_token);
 
-		let currentLevel: AuthenticatorAssuranceLevels | null = null;
+				let currentLevel: AuthenticatorAssuranceLevels | null = null;
 
-		if (payload.aal) {
-			currentLevel = payload.aal;
-		}
+				if (payload.aal) {
+					currentLevel = payload.aal;
+				}
 
-		let nextLevel: AuthenticatorAssuranceLevels | null = currentLevel;
+				let nextLevel: AuthenticatorAssuranceLevels | null = currentLevel;
 
-		const verifiedFactors = session.user.factors?.filter((factor: Factor) => factor.status === 'verified') ?? [];
+				const verifiedFactors = session.user.factors?.filter((factor: Factor) => factor.status === 'verified') ?? [];
 
-		if (verifiedFactors.length > 0) {
-			nextLevel = 'aal2';
-		}
+				if (verifiedFactors.length > 0) {
+					nextLevel = 'aal2';
+				}
 
-		const currentAuthenticationMethods = payload.amr || [];
+				const currentAuthenticationMethods = payload.amr || [];
 
-		return { data: { currentLevel, nextLevel, currentAuthenticationMethods }, error: null };
+				return { data: { currentLevel, nextLevel, currentAuthenticationMethods }, error: null };
+			});
+		});
 	}
 }

--- a/packages/nativescript-supabase-gotrue/index.ts
+++ b/packages/nativescript-supabase-gotrue/index.ts
@@ -1,5 +1,8 @@
 import GoTrueAdminApi from './GoTrueAdminApi';
 import GoTrueClient from './GoTrueClient';
-export { GoTrueAdminApi, GoTrueClient };
+import AuthAdminApi from './AuthAdminApi';
+import AuthClient from './AuthClient';
+export { GoTrueAdminApi, GoTrueClient, AuthAdminApi, AuthClient };
 export * from './lib/types';
 export * from './lib/errors';
+// export { navigatorLock, NavigatorLockAcquireTimeoutError, internals as lockInternals } from './lib/locks';

--- a/packages/nativescript-supabase-gotrue/lib/errors.ts
+++ b/packages/nativescript-supabase-gotrue/lib/errors.ts
@@ -1,3 +1,5 @@
+import { WeakPasswordReasons } from './types';
+
 export class AuthError extends Error {
 	status: number | undefined;
 	protected __isAuthError = true;
@@ -69,6 +71,12 @@ export class AuthSessionMissingError extends CustomAuthError {
 	}
 }
 
+export class AuthInvalidTokenResponseError extends CustomAuthError {
+	constructor() {
+		super('Auth session or user missing', 'AuthInvalidTokenResponseError', 500);
+	}
+}
+
 export class AuthInvalidCredentialsError extends CustomAuthError {
 	constructor(message: string) {
 		super(message, 'AuthInvalidCredentialsError', 400);
@@ -113,4 +121,30 @@ export class AuthRetryableFetchError extends CustomAuthError {
 	constructor(message: string, status: number) {
 		super(message, 'AuthRetryableFetchError', status);
 	}
+}
+
+export function isAuthRetryableFetchError(error: unknown): error is AuthRetryableFetchError {
+	return isAuthError(error) && error.name === 'AuthRetryableFetchError';
+}
+
+/**
+ * This error is thrown on certain methods when the password used is deemed
+ * weak. Inspect the reasons to identify what password strength rules are
+ * inadequate.
+ */
+export class AuthWeakPasswordError extends CustomAuthError {
+	/**
+	 * Reasons why the password is deemed weak.
+	 */
+	reasons: WeakPasswordReasons[];
+
+	constructor(message: string, status: number, reasons: string[]) {
+		super(message, 'AuthWeakPasswordError', status);
+
+		this.reasons = reasons;
+	}
+}
+
+export function isAuthWeakPasswordError(error: unknown): error is AuthWeakPasswordError {
+	return isAuthError(error) && error.name === 'AuthWeakPasswordError';
 }

--- a/packages/nativescript-supabase-gotrue/lib/local-storage.ts
+++ b/packages/nativescript-supabase-gotrue/lib/local-storage.ts
@@ -1,7 +1,8 @@
+// custom: use ApplicationSettings as local storage in NativeScript
 import { SupportedStorage } from './types';
 import { ApplicationSettings } from '@nativescript/core';
 
-const localStorageAdapter: SupportedStorage = {
+export const localStorageAdapter: SupportedStorage = {
 	getItem: (key) => {
 		return ApplicationSettings.getString(key);
 	},
@@ -13,4 +14,22 @@ const localStorageAdapter: SupportedStorage = {
 	},
 };
 
-export default localStorageAdapter;
+/**
+ * Returns a localStorage-like object that stores the key-value pairs in
+ * memory.
+ */
+export function memoryLocalStorageAdapter(store: { [key: string]: string } = {}): SupportedStorage {
+	return {
+		getItem: (key) => {
+			return store[key] || null;
+		},
+
+		setItem: (key, value) => {
+			store[key] = value;
+		},
+
+		removeItem: (key) => {
+			delete store[key];
+		},
+	};
+}

--- a/packages/nativescript-supabase-gotrue/lib/locks.ts
+++ b/packages/nativescript-supabase-gotrue/lib/locks.ts
@@ -1,0 +1,124 @@
+// import { supportsLocalStorage } from './helpers';
+
+// /**
+//  * @experimental
+//  */
+// export const internals = {
+// 	/**
+// 	 * @experimental
+// 	 */
+// 	debug: !!(globalThis && supportsLocalStorage() && globalThis.localStorage && globalThis.localStorage.getItem('supabase.gotrue-js.locks.debug') === 'true'),
+// };
+
+// /**
+//  * An error thrown when a lock cannot be acquired after some amount of time.
+//  *
+//  * Use the {@link #isAcquireTimeout} property instead of checking with `instanceof`.
+//  */
+// export abstract class LockAcquireTimeoutError extends Error {
+// 	public readonly isAcquireTimeout = true;
+
+// 	constructor(message: string) {
+// 		super(message);
+// 	}
+// }
+
+// export class NavigatorLockAcquireTimeoutError extends LockAcquireTimeoutError {}
+
+// /**
+//  * Implements a global exclusive lock using the Navigator LockManager API. It
+//  * is available on all browsers released after 2022-03-15 with Safari being the
+//  * last one to release support. If the API is not available, this function will
+//  * throw. Make sure you check availablility before configuring {@link
+//  * GoTrueClient}.
+//  *
+//  * You can turn on debugging by setting the `supabase.gotrue-js.locks.debug`
+//  * local storage item to `true`.
+//  *
+//  * Internals:
+//  *
+//  * Since the LockManager API does not preserve stack traces for the async
+//  * function passed in the `request` method, a trick is used where acquiring the
+//  * lock releases a previously started promise to run the operation in the `fn`
+//  * function. The lock waits for that promise to finish (with or without error),
+//  * while the function will finally wait for the result anyway.
+//  *
+//  * @param name Name of the lock to be acquired.
+//  * @param acquireTimeout If negative, no timeout. If 0 an error is thrown if
+//  *                       the lock can't be acquired without waiting. If positive, the lock acquire
+//  *                       will time out after so many milliseconds. An error is
+//  *                       a timeout if it has `isAcquireTimeout` set to true.
+//  * @param fn The operation to run once the lock is acquired.
+//  */
+// export async function navigatorLock<R>(name: string, acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
+// 	if (internals.debug) {
+// 		console.log('@supabase/gotrue-js: navigatorLock: acquire lock', name, acquireTimeout);
+// 	}
+
+// 	const abortController = new globalThis.AbortController();
+
+// 	if (acquireTimeout > 0) {
+// 		setTimeout(() => {
+// 			abortController.abort();
+// 			if (internals.debug) {
+// 				console.log('@supabase/gotrue-js: navigatorLock acquire timed out', name);
+// 			}
+// 		}, acquireTimeout);
+// 	}
+
+// 	// MDN article: https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
+
+// 	return await globalThis.navigator.locks.request(
+// 		name,
+// 		acquireTimeout === 0
+// 			? {
+// 					mode: 'exclusive',
+// 					ifAvailable: true,
+// 			  }
+// 			: {
+// 					mode: 'exclusive',
+// 					signal: abortController.signal,
+// 			  },
+// 		async (lock) => {
+// 			if (lock) {
+// 				if (internals.debug) {
+// 					console.log('@supabase/gotrue-js: navigatorLock: acquired', name, lock.name);
+// 				}
+
+// 				try {
+// 					return await fn();
+// 				} finally {
+// 					if (internals.debug) {
+// 						console.log('@supabase/gotrue-js: navigatorLock: released', name, lock.name);
+// 					}
+// 				}
+// 			} else {
+// 				if (acquireTimeout === 0) {
+// 					if (internals.debug) {
+// 						console.log('@supabase/gotrue-js: navigatorLock: not immediately available', name);
+// 					}
+
+// 					throw new NavigatorLockAcquireTimeoutError(`Acquiring an exclusive Navigator LockManager lock "${name}" immediately failed`);
+// 				} else {
+// 					if (internals.debug) {
+// 						try {
+// 							const result = await globalThis.navigator.locks.query();
+
+// 							console.log('@supabase/gotrue-js: Navigator LockManager state', JSON.stringify(result, null, '  '));
+// 						} catch (e: any) {
+// 							console.warn('@supabase/gotrue-js: Error when querying Navigator LockManager state', e);
+// 						}
+// 					}
+
+// 					// Browser is not following the Navigator LockManager spec, it
+// 					// returned a null lock when we didn't use ifAvailable. So we can
+// 					// pretend the lock is acquired in the name of backward compatibility
+// 					// and user experience and just run the function.
+// 					console.warn('@supabase/gotrue-js: Navigator LockManager returned a null lock when using #request without ifAvailable set to true, it appears this browser is not following the LockManager spec https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request');
+
+// 					return await fn();
+// 				}
+// 			}
+// 		}
+// 	);
+// }

--- a/packages/nativescript-supabase-gotrue/lib/types.ts
+++ b/packages/nativescript-supabase-gotrue/lib/types.ts
@@ -52,6 +52,12 @@ export type GoTrueClientOptions = {
 	 * @experimental
 	 */
 	lock?: LockFunc;
+
+  // custom in NativeScript
+  /**
+   * Whether or not to allow an expired session to be used in case the initial refresh fails (ie. the user is offline).
+   */
+  allowExpiredSession?: boolean;
 };
 
 export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | string;

--- a/packages/nativescript-supabase-gotrue/lib/types.ts
+++ b/packages/nativescript-supabase-gotrue/lib/types.ts
@@ -2,11 +2,28 @@ import { AuthError } from './errors';
 import { Fetch } from './fetch';
 
 /** One of the providers supported by GoTrue. */
-export type Provider = 'apple' | 'azure' | 'bitbucket' | 'discord' | 'facebook' | 'github' | 'gitlab' | 'google' | 'keycloak' | 'linkedin' | 'notion' | 'slack' | 'spotify' | 'twitch' | 'twitter' | 'workos';
+export type Provider = 'apple' | 'azure' | 'bitbucket' | 'discord' | 'facebook' | 'figma' | 'github' | 'gitlab' | 'google' | 'kakao' | 'keycloak' | 'linkedin' | 'linkedin_oidc' | 'notion' | 'slack' | 'spotify' | 'twitch' | 'twitter' | 'workos' | 'zoom' | 'fly';
 
 export type AuthChangeEventMFA = 'MFA_CHALLENGE_VERIFIED';
 
 export type AuthChangeEvent = 'INITIAL_SESSION' | 'PASSWORD_RECOVERY' | 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED' | 'USER_UPDATED' | AuthChangeEventMFA;
+
+/**
+ * Provide your own global lock implementation instead of the default
+ * implementation. The function should acquire a lock for the duration of the
+ * `fn` async function, such that no other client instances will be able to
+ * hold it at the same time.
+ *
+ * @experimental
+ *
+ * @param name Name of the lock to be acquired.
+ * @param acquireTimeout If negative, no timeout should occur. If positive it
+ *                       should throw an Error with an `isAcquireTimeout`
+ *                       property set to true if the operation fails to be
+ *                       acquired after this much time (ms).
+ * @param fn The operation to execute when the lock is acquired.
+ */
+export type LockFunc = <R>(name: string, acquireTimeout: number, fn: () => Promise<R>) => Promise<R>;
 
 export type GoTrueClientOptions = {
 	/* The URL of the GoTrue server. */
@@ -27,6 +44,20 @@ export type GoTrueClientOptions = {
 	fetch?: Fetch;
 	/* If set to 'pkce' PKCE flow. Defaults to the 'implicit' flow otherwise */
 	flowType?: AuthFlowType;
+	/* If debug messages are emitted. Can be used to inspect the behavior of the library. If set to a function, the provided function will be used instead of `console.log()` to perform the logging. */
+	debug?: boolean | ((message: string, ...args: any[]) => void);
+	/**
+	 * Provide your own locking mechanism based on the environment. By default no locking is done at this time.
+	 *
+	 * @experimental
+	 */
+	lock?: LockFunc;
+};
+
+export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | string;
+export type WeakPassword = {
+	reasons: WeakPasswordReasons[];
+	message: string;
 };
 
 export type AuthResponse =
@@ -41,6 +72,72 @@ export type AuthResponse =
 			data: {
 				user: null;
 				session: null;
+			};
+			error: AuthError;
+	  };
+
+export type AuthResponsePassword =
+	| {
+			data: {
+				user: User | null;
+				session: Session | null;
+				weak_password?: WeakPassword | null;
+			};
+			error: null;
+	  }
+	| {
+			data: {
+				user: null;
+				session: null;
+			};
+			error: AuthError;
+	  };
+
+/**
+ * AuthOtpResponse is returned when OTP is used.
+ *
+ * {@see AuthRsponse}
+ */
+export type AuthOtpResponse =
+	| {
+			data: { user: null; session: null; messageId?: string | null };
+			error: null;
+	  }
+	| {
+			data: { user: null; session: null; messageId?: string | null };
+			error: AuthError;
+	  };
+
+export type AuthTokenResponse =
+	| {
+			data: {
+				user: User;
+				session: Session;
+			};
+			error: null;
+	  }
+	| {
+			data: {
+				user: null;
+				session: null;
+			};
+			error: AuthError;
+	  };
+
+export type AuthTokenResponsePassword =
+	| {
+			data: {
+				user: User;
+				session: Session;
+				weakPassword?: WeakPassword;
+			};
+			error: null;
+	  }
+	| {
+			data: {
+				user: null;
+				session: null;
+				weakPassword?: null;
 			};
 			error: AuthError;
 	  };
@@ -149,6 +246,7 @@ export interface UserIdentity {
 	identity_data?: {
 		[key: string]: any;
 	};
+	identity_id: string;
 	provider: string;
 	created_at?: string;
 	last_sign_in_at?: string;
@@ -233,6 +331,13 @@ export interface UserAttributes {
 	password?: string;
 
 	/**
+	 * The nonce sent for reauthentication if the user's password is to be updated.
+	 *
+	 * Call reauthenticate() to obtain the nonce first.
+	 */
+	nonce?: string;
+
+	/**
 	 * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
 	 *
 	 * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
@@ -289,6 +394,15 @@ export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
 	 * Setting the ban duration to 'none' lifts the ban on the user.
 	 */
 	ban_duration?: string | 'none';
+
+	/**
+	 * The `role` claim set in the user's access token JWT.
+	 *
+	 * When a user signs up, this role is set to `authenticated` by default. You should only modify the `role` if you need to provision several levels of admin access that have different permissions on individual columns in your database.
+	 *
+	 * Setting this role to `service_role` is not recommended as it grants the user admin privileges.
+	 */
+	role?: string;
 }
 
 export interface Subscription {
@@ -430,13 +544,13 @@ export type SignInWithOAuthCredentials = {
 };
 
 export type SignInWithIdTokenCredentials = {
-	/**
-	 * Only Apple and Google ID tokens are supported for use from within iOS or Android applications.
-	 */
-	provider: 'google' | 'apple';
-	/** ID token issued by Apple or Google. */
+	/** Provider name or OIDC `iss` value identifying which provider should be used to verify the provided token. Supported names: `google`, `apple`, `azure`, `facebook`, `keycloak` (deprecated). */
+	provider: 'google' | 'apple' | 'azure' | 'facebook' | string;
+	/** OIDC ID token issued by the specified provider. The `iss` claim in the ID token must match the supplied provider. Some ID tokens contain an `at_hash` which require that you provide an `access_token` value to be accepted properly. If the token contains a `nonce` claim you must supply the nonce used to obtain the ID token. */
 	token: string;
-	/** If the ID token contains a `nonce`, then the hash of this value is compared to the value in the ID token. */
+	/** If the ID token contains an `at_hash` claim, then the hash of this value is compared to the value in the ID token. */
+	access_token?: string;
+	/** If the ID token contains a `nonce` claim, then the hash of this value is compared to the value in the ID token. */
 	nonce?: string;
 	options?: {
 		/** Verification token received when the user completes the captcha on the site. */
@@ -444,7 +558,7 @@ export type SignInWithIdTokenCredentials = {
 	};
 };
 
-export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams;
+export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams | VerifyTokenHashParams;
 export interface VerifyMobileOtpParams {
 	/** The user's phone number. */
 	phone: string;
@@ -474,13 +588,45 @@ export interface VerifyEmailOtpParams {
 	options?: {
 		/** A URL to send the user to after they are confirmed. */
 		redirectTo?: string;
-		/** Verification token received when the user completes the captcha on the site. */
+
+		/** Verification token received when the user completes the captcha on the site.
+		 *
+		 * @deprecated
+		 */
 		captchaToken?: string;
 	};
 }
 
+export interface VerifyTokenHashParams {
+	/** The token hash used in an email link */
+	token_hash: string;
+
+	/** The user's verification type. */
+	type: EmailOtpType;
+}
+
 export type MobileOtpType = 'sms' | 'phone_change';
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change' | 'email';
+
+export type ResendParams =
+	| {
+			type: Extract<EmailOtpType, 'signup' | 'email_change'>;
+			email: string;
+			options?: {
+				/** A URL to send the user to after they have signed-in. */
+				emailRedirectTo?: string;
+				/** Verification token received when the user completes the captcha on the site. */
+				captchaToken?: string;
+			};
+	  }
+	| {
+			type: Extract<MobileOtpType, 'sms' | 'phone_change'>;
+			phone: string;
+			options?: {
+				/** Verification token received when the user completes the captcha on the site. */
+				captchaToken?: string;
+			};
+	  };
 
 export type SignInWithSSO =
 	| {
@@ -678,6 +824,8 @@ export type AuthMFAEnrollResponse =
 					 * to use it. Avoid loggin this value to the console. */
 					uri: string;
 				};
+				/** Friendly name of the factor, useful for distinguishing between factors **/
+				friendly_name?: string;
 			};
 			error: null;
 	  }
@@ -917,4 +1065,18 @@ export type PageParams = {
 	page?: number;
 	/** Number of items returned per page */
 	perPage?: number;
+};
+
+export type SignOut = {
+	/**
+	 * Determines which sessions should be
+	 * logged out. Global means all
+	 * sessions by this account. Local
+	 * means only this session. Others
+	 * means all other sessions except the
+	 * current one. When using others,
+	 * there is no sign-out event fired on
+	 * the current session!
+	 */
+	scope?: 'global' | 'local' | 'others';
 };

--- a/packages/nativescript-supabase/SupabaseClient.ts
+++ b/packages/nativescript-supabase/SupabaseClient.ts
@@ -199,7 +199,7 @@ export default class SupabaseClient<Database = any, SchemaName extends string & 
 		return data.session?.access_token ?? null;
 	}
 
-	private _initSupabaseAuthClient({ autoRefreshToken, persistSession, detectSessionInUrl, storage, storageKey, flowType }: SupabaseAuthClientOptions, headers?: Record<string, string>, fetch?: Fetch) {
+	private _initSupabaseAuthClient({ autoRefreshToken, persistSession, detectSessionInUrl, storage, storageKey, flowType, ...rest }: SupabaseAuthClientOptions, headers?: Record<string, string>, fetch?: Fetch) {
 		const authHeaders = {
 			Authorization: `Bearer ${this.supabaseKey}`,
 			apikey: `${this.supabaseKey}`,
@@ -214,6 +214,7 @@ export default class SupabaseClient<Database = any, SchemaName extends string & 
 			storage,
 			flowType,
 			fetch,
+			...rest,
 		});
 	}
 


### PR DESCRIPTION
Updated to latest GoTrue client.

Added support for `allowExpiredSession` + adjusted session logic so if there's an existing session from storage, we keep it in case an authRetryableError happens (ie. the session expired, but we failed to refresh it). This allows the session to stay alive even when the user is offline, as a refresh will still happen once online.