### PR TITLE
[nativescript-videorecorder] iOS Fix cancel event

### DIFF
--- a/packages/nativescript-videorecorder/index.ios.ts
+++ b/packages/nativescript-videorecorder/index.ios.ts
@@ -205,6 +205,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject implements UIImagePic
 	}
 
 	imagePickerControllerDidCancel(picker: any /*UIImagePickerController*/) {
+    this._reject({ event: 'cancelled' });
 		picker.presentingViewController.dismissViewControllerAnimatedCompletion(true, null);
 		listener = null;
 	}


### PR DESCRIPTION
Cancelling the iOS camera does not resolve the recording promise. Fix this by calling the reject callback with the `{event: 'cancelled'}`