### PR TITLE
[Android] Fix export 'LogLevel' (imported as 'LogLevel') was not found in '@triniwiz/nativescript-ffmpeg'

### DIFF
--- a/packages/nativescript-ffmpeg/index.android.ts
+++ b/packages/nativescript-ffmpeg/index.android.ts
@@ -1,5 +1,7 @@
 import { LogLevel, TNSLogBase, TNSLogRedirectionStrategy, TNSMediaInformationBase, TNSMediaStreamBase, TNSReturnCodeBase, TNSSessionBase, TNSSessionState, TNSStatisticsBase } from './common';
 
+export { LogLevel };
+
 export class TNSSession extends TNSSessionBase {
 	native: com.arthenica.ffmpegkit.Session;
 	get android() {

--- a/packages/nativescript-videorecorder/index.ios.ts
+++ b/packages/nativescript-videorecorder/index.ios.ts
@@ -205,6 +205,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject implements UIImagePic
 	}
 
 	imagePickerControllerDidCancel(picker: any /*UIImagePickerController*/) {
+    this._reject({ event: 'cancelled' });
 		picker.presentingViewController.dismissViewControllerAnimatedCompletion(true, null);
 		listener = null;
 	}


### PR DESCRIPTION
Fixes missing export of `LogLevel` for Android

```
export 'LogLevel' (imported as 'LogLevel') was not found in '@triniwiz/nativescript-ffmpeg' (possible exports: FFmpeg, TNSLog, TNSMediaInformation, TNSMediaStream, TNSReturnCode, TNSSession, TNSStatistics)
``` 