### PR TITLE
(nativescript-stripe) Fix paymentSheet returning "unknown" in iOS & misspelled word in Android

### DIFF
--- a/packages/nativescript-stripe/paymentSheet/index.android.ts
+++ b/packages/nativescript-stripe/paymentSheet/index.android.ts
@@ -17,7 +17,12 @@ export class PaymentSheet {
                 } else if (result instanceof com.stripe.android.paymentsheet.PaymentSheetResult.Canceled) {
                     PaymentSheet.#reject(new Error('cancelled'));
                 } else {
-                    PaymentSheet.#reject(new Error('unknown'));
+                    /** 
+                     * Note: previously this was returning just "unknown" - this has proven difficult to debug
+                     * for developers implementing this in their app. So better to return something that includes
+                     * original message.
+                     */
+                    PaymentSheet.#reject(new Error(`unknown error: ${JSON.stringify(result)}`));
                 }
                 PaymentSheet.#reject = undefined;
                 PaymentSheet.#resolve = undefined;

--- a/packages/nativescript-stripe/paymentSheet/index.android.ts
+++ b/packages/nativescript-stripe/paymentSheet/index.android.ts
@@ -15,7 +15,7 @@ export class PaymentSheet {
                     (error as any).native = result.getError();
                     PaymentSheet.#reject(error);
                 } else if (result instanceof com.stripe.android.paymentsheet.PaymentSheetResult.Canceled) {
-                    PaymentSheet.#reject(new Error('canceled'));
+                    PaymentSheet.#reject(new Error('cancelled'));
                 } else {
                     PaymentSheet.#reject(new Error('unknown'));
                 }

--- a/packages/nativescript-stripe/paymentSheet/index.ios.ts
+++ b/packages/nativescript-stripe/paymentSheet/index.ios.ts
@@ -29,6 +29,7 @@ export class PaymentSheet {
                         resolve();
                         break;
                     case "cancelled":
+                    case "canceled": // Stripe seems to return this misspelled variant
                         reject(new Error('cancelled'))
                         break;
                     case "error":
@@ -37,7 +38,12 @@ export class PaymentSheet {
                         reject(err)
                         break;
                     default:
-                        reject(new Error('unknown'));
+                        /** 
+                         * Note: previously this was returning just "undefined" - this has proven difficult to debug
+                         * for developers implementing this in their app. So better to return something that includes
+                         * original message.
+                         */
+                        reject(new Error(`unknown error: ${JSON.stringify(status)}`));
                         break;
                 }
             });

--- a/packages/nativescript-stripe/paymentSheet/index.ios.ts
+++ b/packages/nativescript-stripe/paymentSheet/index.ios.ts
@@ -39,7 +39,7 @@ export class PaymentSheet {
                         break;
                     default:
                         /** 
-                         * Note: previously this was returning just "undefined" - this has proven difficult to debug
+                         * Note: previously this was returning just "unknown" - this has proven difficult to debug
                          * for developers implementing this in their app. So better to return something that includes
                          * original message.
                          */


### PR DESCRIPTION
So, this simple change brings:
- for ios, the ability to now have propert "cancelled" message returned in the thrown error - previously it was throwing "unknown" from default case, which was no good.
- for android: alignment with ios, to return "cancelled" rather than "canceled". 

Appreciate the bottom one (android) would possibly be a breaking change, however: if anyone did implement this ever, then they must already be catching both the case of "cancelled" and "canceled" - as that seems to be what it USED to be in ios as well (assuming that the code in the package already worked sometime back). 