### PR TITLE
fix(youtubeplayer): use youtube-nocookie.com origin to fix error 152 on iOS

### DIFF
--- a/packages/nativescript-youtubeplayer/index.ios.ts
+++ b/packages/nativescript-youtubeplayer/index.ios.ts
@@ -41,7 +41,7 @@ export class YoutubePlayer extends YoutubePlayerBase {
 	#state: YoutubePlayerState = YoutubePlayerState.Unstarted;
 
 	createNativeView() {
-		this.#origin = 'https://www.youtube.com';
+		this.#origin = 'https://www.youtube-nocookie.com/embed/';
 		const jScript = `var meta = document.createElement('meta');
                 meta.setAttribute('name', 'viewport');
                 meta.setAttribute('content', 'width=device-width, shrink-to-fit=YES');


### PR DESCRIPTION
## Summary

- Change the YouTube iframe player `origin` from `https://www.youtube.com` to `https://www.youtube-nocookie.com/embed/` in the iOS implementation (`index.ios.ts`)

## Problem

YouTube tightened their embed verification in 2025. All WKWebView-based YouTube iframe embeds that set `origin: 'https://www.youtube.com'` now receive **error 152-4** ("This video is unavailable"). 

The root cause is that `WKWebView.loadHTMLString:baseURL:` does not send proper HTTP `Referer` headers for cross-origin requests (WebKit Bug 169846), so YouTube's iframe API rejects the mismatched origin.

This affects **all videos** — not specific ones.

## Fix

Use `https://www.youtube-nocookie.com/embed/` as the origin, which is the confirmed workaround adopted across multiple communities:

- Flutter: [youtube_player_flutter#1087](https://github.com/sarbagyastha/youtube_player_flutter/issues/1087)
- React Native: [react-native-webview#3889](https://github.com/react-native-webview/react-native-webview/issues/3889)
- iOS WKWebView: [YoutubePlayer-in-WKWebView#43](https://github.com/hmhv/YoutubePlayer-in-WKWebView/issues/43)

## Test plan

- [x] Tested on iOS device (iPhone) with NativeScript Vue 3 app
- [x] Videos that previously showed error 152-4 now load and play correctly